### PR TITLE
 Add MetricsFactory.remove(Metric) to allow metric lifetime management #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 .xcode
 .SourceKitten
+*.orig

--- a/Tests/MetricsTests/CoreMetricsTests+XCTest.swift
+++ b/Tests/MetricsTests/CoreMetricsTests+XCTest.swift
@@ -39,6 +39,7 @@ extension MetricsTests {
                 ("testGaugeBlock", testGaugeBlock),
                 ("testMUX", testMUX),
                 ("testCustomFactory", testCustomFactory),
+                ("testReleasingMetrics", testReleasingMetrics),
            ]
    }
 }

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -257,7 +257,7 @@ class MetricsTests: XCTestCase {
         XCTAssertEqual(metrics.recorders.count, 1, "recorder should have been stored")
 
         let identity = ObjectIdentifier(recorder)
-        MetricsSystem.factory.release(metric: gauge)
+        MetricsSystem.factory.remove(metric: gauge)
         XCTAssertEqual(metrics.recorders.count, 0, "recorder should have been released")
 
         let gaugeAgain = Gauge(label: name)

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -46,7 +46,7 @@ internal class TestMetrics: MetricsFactory {
         }
     }
 
-    public func release<M: Metric>(metric: M) {
+    public func remove<M: Metric>(metric: M) {
         switch metric {
         case let counter as Counter:
             self.counters.removeValue(forKey: counter.label)


### PR DESCRIPTION
Implements #2 
Based on top of https://github.com/apple/swift-metrics/pull/1 which should land without issues I think, so saving this PR some rebasing work 

Rebased and adjusted from https://github.com/tomerd/swift-server-metrics-api-proposal/pull/11

Feedback welcome, see for more details in the previous PR as well as ticket https://github.com/tomerd/swift-server-metrics-api-proposal/issues/6 as well.

Note that we now don't have a [caching one](https://github.com/apple/swift-metrics/commit/3ee8da0728bfed9292eeacc531ce7b1143890d43) since it was only in the examples, and that's the type of implementations where the release matters the most. So the test is a bit weird, but since the test metrics store internally anyway the test does cover that the right things happen, even if it does not return the "cached one"