### PR TITLE
rename Counter::increment "value" parameter to "by"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The API supports four metric types:
 `Counter`: A counter is a cumulative metric that represents a single monotonically increasing counter whose value can only increase or be reset to zero on restart. For example, you can use a counter to represent the number of requests served, tasks completed, or errors.
 
 ```swift
-counter.increment(100)
+counter.increment(by: 100)
 ```
 
 `Recorder`: A recorder collects observations within a time window (usually things like response sizes) and *can* provide aggregated information about the data sample, for example count, sum, min, max and various quantiles.
@@ -128,7 +128,7 @@ The `MetricsFactory` is responsible for instantiating the concrete metrics class
 
 ```swift
 public protocol CounterHandler: AnyObject {
-    func increment(_ by: Int64)
+    func increment(by: Int64)
 }
 ```
 
@@ -173,9 +173,9 @@ class SimpleMetricsLibrary: MetricsFactory {
 
         let lock = NSLock()
         var value: Int64 = 0
-        func increment(_ by: Int64) {
+        func increment(by amount: Int64) {
             self.lock.withLock {
-                self.value += by
+                self.value += amount
             }
         }
 

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -28,7 +28,7 @@ public protocol CounterHandler: AnyObject {
     ///
     /// - parameters:
     ///     - by: Amount to increment by.
-    func increment(_ by: Int64)
+    func increment(by: Int64)
     /// Reset the counter back to zero.
     func reset()
 }
@@ -62,14 +62,14 @@ public class Counter {
     /// - parameters:
     ///     - by: Amount to increment by.
     @inlinable
-    public func increment<DataType: BinaryInteger>(_ by: DataType) {
-        self.handler.increment(Int64(by))
+    public func increment<DataType: BinaryInteger>(by amount: DataType) {
+        self.handler.increment(by: Int64(amount))
     }
 
     /// Increment the counter by one.
     @inlinable
     public func increment() {
-        self.increment(1)
+        self.increment(by: 1)
     }
 
     /// Reset the counter back to zero.
@@ -394,8 +394,8 @@ public final class MultiplexMetricsHandler: MetricsFactory {
             self.counters = factories.map { $0.makeCounter(label: label, dimensions: dimensions) }
         }
 
-        func increment(_ by: Int64) {
-            self.counters.forEach { $0.increment(by) }
+        func increment(by amount: Int64) {
+            self.counters.forEach { $0.increment(by: amount) }
         }
 
         func reset() {
@@ -448,7 +448,7 @@ public final class NOOPMetricsHandler: MetricsFactory, CounterHandler, RecorderH
         return self
     }
 
-    public func increment(_: Int64) {}
+    public func increment(by: Int64) {}
     public func reset() {}
     public func record(_: Int64) {}
     public func record(_: Double) {}

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -28,7 +28,7 @@ class MetricsTests: XCTestCase {
         for _ in 0 ... total {
             group.enter()
             DispatchQueue(label: "\(name)-queue").async {
-                counter.increment(Int.random(in: 0 ... 1000))
+                counter.increment(by: Int.random(in: 0 ... 1000))
                 group.leave()
             }
         }
@@ -45,7 +45,7 @@ class MetricsTests: XCTestCase {
         // run the test
         let name = "counter-\(NSUUID().uuidString)"
         let value = Int.random(in: Int.min ... Int.max)
-        Counter(label: name).increment(value)
+        Counter(label: name).increment(by: value)
         let counter = metrics.counters[name] as! TestCounter
         XCTAssertEqual(counter.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(counter.values[0].1, Int64(value), "expected value to match")
@@ -215,7 +215,7 @@ class MetricsTests: XCTestCase {
         let name = NSUUID().uuidString
         let value = Int.random(in: Int.min ... Int.max)
         let mux = Counter(label: name)
-        mux.increment(value)
+        mux.increment(by: value)
         factories.forEach { factory in
             let counter = factory.counters.first?.1 as! TestCounter
             XCTAssertEqual(counter.label, name, "expected label to match")
@@ -231,7 +231,7 @@ class MetricsTests: XCTestCase {
 
     func testCustomFactory() {
         class CustomHandler: CounterHandler {
-            func increment<DataType>(_: DataType) where DataType: BinaryInteger {}
+            func increment<DataType>(by: DataType) where DataType: BinaryInteger {}
             func reset() {}
         }
 

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -60,11 +60,11 @@ internal class TestCounter: CounterHandler, Equatable {
         self.dimensions = dimensions
     }
 
-    func increment(_ by: Int64) {
+    func increment(by amount: Int64) {
         self.lock.withLock {
-            self.values.append((Date(), by))
+            self.values.append((Date(), amount))
         }
-        print("adding \(by) to \(self.label)")
+        print("adding \(amount) to \(self.label)")
     }
 
     func reset() {


### PR DESCRIPTION
motivation: nicer API signature

changes: rename Counter::increment and  CounterHandler::increment "value" parameter to "by"