### PR TITLE
fix linux tests formatting

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,10 @@
+# file options
+
+# format options
+
+--self insert 
+--patternlet inline 
+--stripunusedargs unnamed-only 
+--comments ignore
+
+# rules

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -23,10 +23,10 @@ import XCTest
 ///
 
 #if os(Linux) || os(FreeBSD)
-   @testable import MetricsTests
+    @testable import MetricsTests
 
-   XCTMain([
-         testCase(MetricsExtensionsTests.allTests),
-         testCase(MetricsTests.allTests),
+    XCTMain([
+        testCase(MetricsExtensionsTests.allTests),
+        testCase(MetricsTests.allTests),
     ])
 #endif

--- a/Tests/MetricsTests/CoreMetricsTests+XCTest.swift
+++ b/Tests/MetricsTests/CoreMetricsTests+XCTest.swift
@@ -23,23 +23,21 @@ import XCTest
 ///
 
 extension MetricsTests {
-
-   static var allTests : [(String, (MetricsTests) -> () throws -> Void)] {
-      return [
-                ("testCounters", testCounters),
-                ("testCounterBlock", testCounterBlock),
-                ("testRecorders", testRecorders),
-                ("testRecordersInt", testRecordersInt),
-                ("testRecordersFloat", testRecordersFloat),
-                ("testRecorderBlock", testRecorderBlock),
-                ("testTimers", testTimers),
-                ("testTimerBlock", testTimerBlock),
-                ("testTimerVariants", testTimerVariants),
-                ("testGauge", testGauge),
-                ("testGaugeBlock", testGaugeBlock),
-                ("testMUX", testMUX),
-                ("testCustomFactory", testCustomFactory),
-           ]
-   }
+    static var allTests: [(String, (MetricsTests) -> () throws -> Void)] {
+        return [
+            ("testCounters", testCounters),
+            ("testCounterBlock", testCounterBlock),
+            ("testRecorders", testRecorders),
+            ("testRecordersInt", testRecordersInt),
+            ("testRecordersFloat", testRecordersFloat),
+            ("testRecorderBlock", testRecorderBlock),
+            ("testTimers", testTimers),
+            ("testTimerBlock", testTimerBlock),
+            ("testTimerVariants", testTimerVariants),
+            ("testGauge", testGauge),
+            ("testGaugeBlock", testGaugeBlock),
+            ("testMUX", testMUX),
+            ("testCustomFactory", testCustomFactory),
+        ]
+    }
 }
-

--- a/Tests/MetricsTests/MetricsTests+XCTest.swift
+++ b/Tests/MetricsTests/MetricsTests+XCTest.swift
@@ -23,13 +23,11 @@ import XCTest
 ///
 
 extension MetricsExtensionsTests {
-
-   static var allTests : [(String, (MetricsExtensionsTests) -> () throws -> Void)] {
-      return [
-                ("testTimerBlock", testTimerBlock),
-                ("testTimerWithTimeInterval", testTimerWithTimeInterval),
-                ("testTimerWithDispatchTime", testTimerWithDispatchTime),
-           ]
-   }
+    static var allTests: [(String, (MetricsExtensionsTests) -> () throws -> Void)] {
+        return [
+            ("testTimerBlock", testTimerBlock),
+            ("testTimerWithTimeInterval", testTimerWithTimeInterval),
+            ("testTimerWithDispatchTime", testTimerWithDispatchTime),
+        ]
+    }
 }
-

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -71,17 +71,17 @@ def createExtensionFile(fileName, classes)
     file.write "\n"
 
     for classArray in classes
-      file.write 'extension ' + classArray[0] + " {\n\n"
-      file.write '   static var allTests : [(String, (' + classArray[0] + ") -> () throws -> Void)] {\n"
-      file.write "      return [\n"
+      file.write 'extension ' + classArray[0] + " {\n"
+      file.write '    static var allTests: [(String, (' + classArray[0] + ") -> () throws -> Void)] {\n"
+      file.write "        return [\n"
 
       for funcName in classArray[1]
-        file.write '                ("' + funcName + '", ' + funcName + "),\n"
+        file.write '            ("' + funcName + '", ' + funcName + "),\n"
       end
 
-      file.write "           ]\n"
-      file.write "   }\n"
-      file.write "}\n\n"
+      file.write "        ]\n"
+      file.write "    }\n"
+      file.write "}\n"
     end
   end
 end
@@ -96,10 +96,10 @@ def createLinuxMain(testsDirectory, allTestSubDirectories, files)
 
     file.write "#if os(Linux) || os(FreeBSD)\n"
     for testSubDirectory in allTestSubDirectories.sort { |x, y| x <=> y }
-      file.write '   @testable import ' + testSubDirectory + "\n"
+      file.write '    @testable import ' + testSubDirectory + "\n"
     end
     file.write "\n"
-    file.write "   XCTMain([\n"
+    file.write "    XCTMain([\n"
 
     testCases = []
     for classes in files
@@ -109,7 +109,7 @@ def createLinuxMain(testsDirectory, allTestSubDirectories, files)
     end
 
     for testCase in testCases.sort { |x, y| x <=> y }
-      file.write '         testCase(' + testCase + ".allTests),\n"
+      file.write '        testCase(' + testCase + ".allTests),\n"
     end
     file.write "    ])\n"
     file.write "#endif\n"


### PR DESCRIPTION
motivation: use consistent formatting

changes: update generate_linux_tests to match the formatting rules we use: `swiftformat --self insert --patternlet inline --stripunusedargs unnamed-only --comments ignore`