### PR TITLE
doc: #26 clarify which init to use, reformat docs for easier noticing this

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -36,17 +36,22 @@ public protocol CounterHandler: AnyObject {
 
 /// A counter is a cumulative metric that represents a single monotonically increasing counter whose value can only increase or be reset to zero.
 /// For example, you can use a counter to represent the number of requests served, tasks completed, or errors.
-/// This is the user facing Counter API. Its behavior depends on the `CounterHandler` implementation.
+///
+/// This is the user facing Counter API.
+///
+/// Its behavior depends on the `CounterHandler` implementation.
 public class Counter {
     @usableFromInline
     var handler: CounterHandler
     public let label: String
     public let dimensions: [(String, String)]
 
-    /// Create a new `Counter`.
+    /// Alternative way to create a new `Counter`, while providing an explicit `CounterHandler`.
     ///
     /// This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
     /// We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
+    ///
+    /// - SeeAlso: Use `init(label:dimensions:)` to create `Counter` instances using the configured metrics backend.
     ///
     /// - parameters:
     ///     - label: The label for the `Counter`.
@@ -124,7 +129,10 @@ public protocol RecorderHandler: AnyObject {
 }
 
 /// A recorder collects observations within a time window (usually things like response sizes) and *can* provide aggregated information about the data sample, for example, count, sum, min, max and various quantiles.
-/// This is the user facing Recorder API. Its behavior depends on the `RecorderHandler` implementation.
+///
+/// This is the user facing Recorder API.
+///
+/// Its behavior depends on the `RecorderHandler` implementation.
 public class Recorder {
     @usableFromInline
     var handler: RecorderHandler
@@ -132,10 +140,12 @@ public class Recorder {
     public let dimensions: [(String, String)]
     public let aggregate: Bool
 
-    /// Create a new `Recorder`.
+    /// Alternative way to create a new `Recorder`, while providing an explicit `RecorderHandler`.
     ///
     /// This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
     /// We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
+    ///
+    /// - SeeAlso: Use `init(label:dimensions:)` to create `Recorder` instances using the configured metrics backend.
     ///
     /// - parameters:
     ///     - label: The label for the `Recorder`.
@@ -221,17 +231,22 @@ public protocol TimerHandler: AnyObject {
 
 /// A timer collects observations within a time window (usually things like request durations) and provides aggregated information about the data sample,
 /// for example, min, max and various quantiles. It is similar to a `Recorder` but specialized for values that represent durations.
-/// This is the user facing Timer API. Its behavior depends on the `TimerHandler` implementation.
+///
+/// This is the user facing Timer API.
+///
+/// Its behavior depends on the `TimerHandler` implementation.
 public class Timer {
     @usableFromInline
     var handler: TimerHandler
     public let label: String
     public let dimensions: [(String, String)]
 
-    /// Create a new `Timer`.
+    /// Alternative way to create a new `Timer`, while providing an explicit `TimerHandler`.
     ///
     /// This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
     /// We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
+    ///
+    /// - SeeAlso: Use `init(label:dimensions:)` to create `Recorder` instances using the configured metrics backend.
     ///
     /// - parameters:
     ///     - label: The label for the `Timer`.
@@ -347,8 +362,8 @@ public extension Timer {
 /// * `Recorder` -> `RecorderHandler`
 /// * `Timer` -> `TimerHandler`
 ///
-/// This type is an implementation detail and should not be used directly, unless implementing your own metrics backend.
-/// To use the SwiftMetrics API, please refer to the documentation of `MetricsSystem`.
+/// - warning: This type is an implementation detail and should not be used directly, unless implementing your own metrics backend.
+///            To use the SwiftMetrics API, please refer to the documentation of `MetricsSystem`.
 ///
 /// # Destroying metrics
 ///

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -37,7 +37,7 @@ public protocol CounterHandler: AnyObject {
 /// A counter is a cumulative metric that represents a single monotonically increasing counter whose value can only increase or be reset to zero.
 /// For example, you can use a counter to represent the number of requests served, tasks completed, or errors.
 ///
-/// This is the user facing Counter API.
+/// This is the user-facing Counter API.
 ///
 /// Its behavior depends on the `CounterHandler` implementation.
 public class Counter {
@@ -48,8 +48,8 @@ public class Counter {
 
     /// Alternative way to create a new `Counter`, while providing an explicit `CounterHandler`.
     ///
-    /// This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
-    /// We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
+    /// - warning: This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
+    ///            We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
     ///
     /// - SeeAlso: Use `init(label:dimensions:)` to create `Counter` instances using the configured metrics backend.
     ///
@@ -130,7 +130,7 @@ public protocol RecorderHandler: AnyObject {
 
 /// A recorder collects observations within a time window (usually things like response sizes) and *can* provide aggregated information about the data sample, for example, count, sum, min, max and various quantiles.
 ///
-/// This is the user facing Recorder API.
+/// This is the user-facing Recorder API.
 ///
 /// Its behavior depends on the `RecorderHandler` implementation.
 public class Recorder {
@@ -142,8 +142,8 @@ public class Recorder {
 
     /// Alternative way to create a new `Recorder`, while providing an explicit `RecorderHandler`.
     ///
-    /// This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
-    /// We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
+    /// - warning: This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
+    ///            We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
     ///
     /// - SeeAlso: Use `init(label:dimensions:)` to create `Recorder` instances using the configured metrics backend.
     ///
@@ -232,7 +232,7 @@ public protocol TimerHandler: AnyObject {
 /// A timer collects observations within a time window (usually things like request durations) and provides aggregated information about the data sample,
 /// for example, min, max and various quantiles. It is similar to a `Recorder` but specialized for values that represent durations.
 ///
-/// This is the user facing Timer API.
+/// This is the user-facing Timer API.
 ///
 /// Its behavior depends on the `TimerHandler` implementation.
 public class Timer {
@@ -243,8 +243,8 @@ public class Timer {
 
     /// Alternative way to create a new `Timer`, while providing an explicit `TimerHandler`.
     ///
-    /// This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
-    /// We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
+    /// - warning: This initializer provides an escape hatch for situations where one must use a custom factory instead of the global one.
+    ///            We do not expect this API to be used in normal circumstances, so if you find yourself using it make sure it's for a good reason.
     ///
     /// - SeeAlso: Use `init(label:dimensions:)` to create `Recorder` instances using the configured metrics backend.
     ///


### PR DESCRIPTION
### Motivation:

I noticed on a community chat that it was confusing to some that the first init they noticed was documented as "dont use this".

The specific confusion was:

- first found `init(label: String, dimensions: [(String, String)], handler: TimerHandler)` but it has docs "do not use" (correctly, as the intended one to be used is `init(label:dimensions:)`)
- next looked at the `MetricsFactory`, since seems like that's what "creates things"; but this yields the internal handlers; 

Problem: we did not lead the user to the "right" init function to use, as it is defined a bit below -- in an extension, as we wanted it there to be next to the destroy as then all lifecycle for users is in there.

### Modifications:

- adds more see-also links
- reformats main wording that the "this is main api" etc are more visible 

### Result:

![Screen Shot 2019-05-20 at 12 10 03](https://user-images.githubusercontent.com/120979/57994776-babe7480-7af9-11e9-9b46-cddb637580f8.png)
