### PR TITLE
Update Timer.measure() to use DispatchTime instead of Date

### DIFF
--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -26,9 +26,10 @@ public extension Timer {
     @inlinable
     static func measure<T>(label: String, dimensions: [(String, String)] = [], body: @escaping () throws -> T) rethrows -> T {
         let timer = Timer(label: label, dimensions: dimensions)
-        let start = Date()
+        let start = DispatchTime.now().uptimeNanoseconds
         defer {
-            timer.record(Date().timeIntervalSince(start))
+            let delta = DispatchTime.now().uptimeNanoseconds - start
+            timer.recordNanoseconds(delta)
         }
         return try body()
     }


### PR DESCRIPTION
As per @weissi on the Vapor discord:
You’re using wall time which isn’t right to measure how long a function ran. Imagine your CPU went to sleep or the user changed the date.

This came up in a discussion around a similar implementation in SwiftPrometheus
### Motivation:

This PR aims to avoid scenarios where function durations are messed up due to use of wall time.

### Modifications:

Updated `Timer.measure()` to use a delta of `DispatchTime.now().uptimeNanoseconds` instead of wall time.
### Result:

Nothing for end users, although timing will no longer depend on wall time.