### PR TITLE
Bugfix: Print correct error message if bootstrap is called multiple times

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -346,7 +346,7 @@ public enum MetricsSystem {
     ///     - factory: A factory that given an identifier produces instances of metrics handlers such as `CounterHandler`, `RecorderHandler` and `TimerHandler`.
     public static func bootstrap(_ factory: MetricsFactory) {
         self.lock.withWriterLock {
-            precondition(!self.initialized, "metrics system can only be initialized once per process. currently used factory: \(self.factory)")
+            precondition(!self.initialized, "metrics system can only be initialized once per process. currently used factory: \(self._factory)")
             self._factory = factory
             self.initialized = true
         }


### PR DESCRIPTION
### Motivation:

MetricsSystem.bootstrap verifies that the metric system has not been previously
initialized. Otherwise it should fail with a corresponding error message. The
precondition error message includes the name of the currently used factory and
for that accesses self.factory. However, because bootstrap already holds
self.lock as a writer lock, self.factory fails to get it as a reader and
crashes with a less useful precondition error message.

Currently, the error message received is:

```
Precondition failed: file [...]/swift-metrics/Sources/CoreMetrics/Locks.swift, line 125
```

### Modifications:

Use `self._factory` instead of `self.factory`.

### Result:

The correct error message is printed:

```
Precondition failed: metrics system can only be initialized once per process. currently used factory: CoreMetrics.NOOPMetricsHandler: file [...]/swift-metrics/Sources/CoreMetrics/Metrics.swift, line 349
```