### PR TITLE
Improve precondition error messages in Lock functions

### DIFF
--- a/Sources/CoreMetrics/Locks.swift
+++ b/Sources/CoreMetrics/Locks.swift
@@ -43,12 +43,12 @@ internal final class Lock {
     /// Create a new lock.
     public init() {
         let err = pthread_mutex_init(self.mutex, nil)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_mutex_init failed with error \(err)")
     }
 
     deinit {
         let err = pthread_mutex_destroy(self.mutex)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_mutex_destroy failed with error \(err)")
         self.mutex.deallocate()
     }
 
@@ -58,7 +58,7 @@ internal final class Lock {
     /// `unlock`, to simplify lock handling.
     public func lock() {
         let err = pthread_mutex_lock(self.mutex)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_mutex_lock failed with error \(err)")
     }
 
     /// Release the lock.
@@ -67,7 +67,7 @@ internal final class Lock {
     /// `lock`, to simplify lock handling.
     public func unlock() {
         let err = pthread_mutex_unlock(self.mutex)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_mutex_unlock failed with error \(err)")
     }
 }
 
@@ -107,12 +107,12 @@ internal final class ReadWriteLock {
     /// Create a new lock.
     public init() {
         let err = pthread_rwlock_init(self.rwlock, nil)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_rwlock_init failed with error \(err)")
     }
 
     deinit {
         let err = pthread_rwlock_destroy(self.rwlock)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_rwlock_destroy failed with error \(err)")
         self.rwlock.deallocate()
     }
 
@@ -122,7 +122,7 @@ internal final class ReadWriteLock {
     /// `unlock`, to simplify lock handling.
     public func lockRead() {
         let err = pthread_rwlock_rdlock(self.rwlock)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_rwlock_rdlock failed with error \(err)")
     }
 
     /// Acquire a writer lock.
@@ -131,7 +131,7 @@ internal final class ReadWriteLock {
     /// `unlock`, to simplify lock handling.
     public func lockWrite() {
         let err = pthread_rwlock_wrlock(self.rwlock)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_rwlock_wrlock failed with error \(err)")
     }
 
     /// Release the lock.
@@ -140,7 +140,7 @@ internal final class ReadWriteLock {
     /// `lock`, to simplify lock handling.
     public func unlock() {
         let err = pthread_rwlock_unlock(self.rwlock)
-        precondition(err == 0)
+        precondition(err == 0, "pthread_rwlock_unlock failed with error \(err)")
     }
 }
 


### PR DESCRIPTION
### Motivation:

The `precondition` calls in Lock functions in `CoreMetrics/Locks.swift` currently do not specify an error message. These obviously should be rare but might be triggered due to other bugs.

Currently, on a precondition failure in `Locks.swift`, errors look like this:

```
Precondition failed: file [...]/swift-metrics/Sources/CoreMetrics/Locks.swift, line 125
```

### Modifications:

Add precondition messages to the `precondition` calls in `CoreMetrics/Locks.swift`.

This commit adds error messages to the precondition checks in Lock functions
that state the action that failed as well as the OS error code.

### Result:

Precondition failures in `Locks.swift` will result in a message like this:

```
Precondition failed: pthread_rwlock_rdlock failed with error 11: file [...]/swift-metrics/Sources/CoreMetrics/Locks.swift, line 125
```