### PR TITLE
Add microseconds to the TimeUnit enum

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -173,7 +173,7 @@ public class Gauge: Recorder {
 }
 
 public enum TimeUnit {
-    case nanoseconds, milliseconds, seconds, minutes, hours, days
+    case nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days
 }
 
 public extension Timer {

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -107,10 +107,10 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000, "expected value to match")
 
         testSecondsTimer.preferDisplayUnit(.microseconds)
-        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000_000, "expected value to match")
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1_000_000, "expected value to match")
 
         testSecondsTimer.preferDisplayUnit(.nanoseconds)
-        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000_000_000, "expected value to match")
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1_000_000_000, "expected value to match")
     }
 }
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -102,6 +102,15 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testSecondsTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 2, "timer should have been stored")
+
+        testSecondsTimer.preferDisplayUnit(.milliseconds)
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000, "expected value to match")
+
+        testSecondsTimer.preferDisplayUnit(.microseconds)
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000_000, "expected value to match")
+
+        testSecondsTimer.preferDisplayUnit(.nanoseconds)
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000_000_000, "expected value to match")
     }
 }
 

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -166,6 +166,7 @@ internal class TestTimer: TimerHandler, Equatable {
             case .minutes: return (value / 1_000_000_000) * 60
             case .seconds: return value / 1_000_000_000
             case .milliseconds: return value / 1_000_000
+            case .microseconds: return value / 1_000
             case .nanoseconds: return value
             }
         }

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -166,7 +166,7 @@ internal class TestTimer: TimerHandler, Equatable {
             case .minutes: return (value / 1_000_000_000) * 60
             case .seconds: return value / 1_000_000_000
             case .milliseconds: return value / 1_000_000
-            case .microseconds: return value / 1_000
+            case .microseconds: return value / 1000
             case .nanoseconds: return value
             }
         }


### PR DESCRIPTION
Motivation:

I have a metrics backend where I need to store timer values in
microseconds. The "preferred display unit" models this exactly, but it
seems to have (inadvertently?) omitted the possibility to express
microseconds. Note that among the timer "report" methods there is
already a microseconds option.

Modifications:

This change merely adds an enum case to express microseconds, which can
be used from preferDisplayUnit. I also expanded the test cases to
exercise preferDisplayUnit appropriately.

Result:

There is no behavioral change, only the new enum case. Which means that
this is technically source breaking, but adoption is almost certainly
trivial.