### PR TITLE
Add microseconds to the TimeUnit enum

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -195,11 +195,11 @@ public struct TimeUnit: Equatable {
 
     public static let nanoseconds = TimeUnit(code: .nanoseconds, scaleFromNanoseconds: 1)
     public static let microseconds = TimeUnit(code: .microseconds, scaleFromNanoseconds: 1000)
-    public static let milliseconds = TimeUnit(code: .milliseconds, scaleFromNanoseconds: 1000 * 1000)
-    public static let seconds = TimeUnit(code: .seconds, scaleFromNanoseconds: 1000 * 1000 * 1000)
-    public static let minutes = TimeUnit(code: .minutes, scaleFromNanoseconds: 60 * 1000 * 1000 * 1000)
-    public static let hours = TimeUnit(code: .hours, scaleFromNanoseconds: 60 * 60 * 1000 * 1000 * 1000)
-    public static let days = TimeUnit(code: .days, scaleFromNanoseconds: 60 * 60 * 24 * 1000 * 1000 * 1000)
+    public static let milliseconds = TimeUnit(code: .milliseconds, scaleFromNanoseconds: 1000 * TimeUnit.microseconds.scaleFromNanoseconds)
+    public static let seconds = TimeUnit(code: .seconds, scaleFromNanoseconds: 1000 * TimeUnit.milliseconds.scaleFromNanoseconds)
+    public static let minutes = TimeUnit(code: .minutes, scaleFromNanoseconds: 60 * TimeUnit.seconds.scaleFromNanoseconds)
+    public static let hours = TimeUnit(code: .hours, scaleFromNanoseconds: 60 * TimeUnit.minutes.scaleFromNanoseconds)
+    public static let days = TimeUnit(code: .days, scaleFromNanoseconds: 24 * TimeUnit.hours.scaleFromNanoseconds)
 }
 
 public extension Timer {

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -173,7 +173,7 @@ public class Gauge: Recorder {
 }
 
 public enum TimeUnit {
-    case nanoseconds, milliseconds, seconds, minutes, hours, days
+    case nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days
 }
 
 public extension Timer {

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -184,9 +184,9 @@ public struct TimeUnit: Equatable {
     }
 
     private let code: Code
-    let scaleFromNanoseconds: UInt
+    let scaleFromNanoseconds: UInt64
 
-    private init(code: Code, scaleFromNanoseconds: UInt) {
+    private init(code: Code, scaleFromNanoseconds: UInt64) {
         assert(scaleFromNanoseconds > 0, "invalid scale from nanoseconds")
 
         self.code = code

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -183,19 +183,23 @@ public struct TimeUnit: Equatable {
         case days
     }
 
-    private var code: Code
+    private let code: Code
+    let scaleFromNanoseconds: UInt
 
-    private init(code: Code) {
+    private init(code: Code, scaleFromNanoseconds: UInt) {
+        assert(scaleFromNanoseconds > 0, "invalid scale from nanoseconds")
+
         self.code = code
+        self.scaleFromNanoseconds = scaleFromNanoseconds
     }
 
-    public static let nanoseconds = TimeUnit(code: .nanoseconds)
-    public static let microseconds = TimeUnit(code: .microseconds)
-    public static let milliseconds = TimeUnit(code: .milliseconds)
-    public static let seconds = TimeUnit(code: .seconds)
-    public static let minutes = TimeUnit(code: .minutes)
-    public static let hours = TimeUnit(code: .hours)
-    public static let days = TimeUnit(code: .days)
+    public static let nanoseconds = TimeUnit(code: .nanoseconds, scaleFromNanoseconds: 1)
+    public static let microseconds = TimeUnit(code: .microseconds, scaleFromNanoseconds: 1000)
+    public static let milliseconds = TimeUnit(code: .milliseconds, scaleFromNanoseconds: 1000 * 1000)
+    public static let seconds = TimeUnit(code: .seconds, scaleFromNanoseconds: 1000 * 1000 * 1000)
+    public static let minutes = TimeUnit(code: .minutes, scaleFromNanoseconds: 60 * 1000 * 1000 * 1000)
+    public static let hours = TimeUnit(code: .hours, scaleFromNanoseconds: 60 * 60 * 1000 * 1000 * 1000)
+    public static let days = TimeUnit(code: .days, scaleFromNanoseconds: 60 * 60 * 24 * 1000 * 1000 * 1000)
 }
 
 public extension Timer {

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -172,8 +172,30 @@ public class Gauge: Recorder {
     }
 }
 
-public enum TimeUnit {
-    case nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days
+public struct TimeUnit: Equatable {
+    private enum Code: Equatable {
+        case nanoseconds
+        case microseconds
+        case milliseconds
+        case seconds
+        case minutes
+        case hours
+        case days
+    }
+
+    private var code: Code
+
+    private init(code: Code) {
+        self.code = code
+    }
+
+    public static let nanoseconds = TimeUnit(code: .nanoseconds)
+    public static let microseconds = TimeUnit(code: .microseconds)
+    public static let milliseconds = TimeUnit(code: .milliseconds)
+    public static let seconds = TimeUnit(code: .seconds)
+    public static let minutes = TimeUnit(code: .minutes)
+    public static let hours = TimeUnit(code: .hours)
+    public static let days = TimeUnit(code: .days)
 }
 
 public extension Timer {

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -184,7 +184,7 @@ public struct TimeUnit: Equatable {
     }
 
     private let code: Code
-    let scaleFromNanoseconds: UInt64
+    public let scaleFromNanoseconds: UInt64
 
     private init(code: Code, scaleFromNanoseconds: UInt64) {
         assert(scaleFromNanoseconds > 0, "invalid scale from nanoseconds")

--- a/Tests/MetricsTests/MetricsTests+XCTest.swift
+++ b/Tests/MetricsTests/MetricsTests+XCTest.swift
@@ -29,6 +29,7 @@ extension MetricsExtensionsTests {
             ("testTimerWithTimeInterval", testTimerWithTimeInterval),
             ("testTimerWithDispatchTime", testTimerWithDispatchTime),
             ("testTimerUnits", testTimerUnits),
+            ("testPreferDisplayUnit", testPreferDisplayUnit),
         ]
     }
 }

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -107,10 +107,10 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000, "expected value to match")
 
         testSecondsTimer.preferDisplayUnit(.microseconds)
-        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000_000, "expected value to match")
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1_000_000, "expected value to match")
 
         testSecondsTimer.preferDisplayUnit(.nanoseconds)
-        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000_000_000, "expected value to match")
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1_000_000_000, "expected value to match")
     }
 }
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -102,15 +102,38 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testSecondsTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 2, "timer should have been stored")
+    }
 
-        testSecondsTimer.preferDisplayUnit(.milliseconds)
-        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000, "expected value to match")
+    func testPreferDisplayUnit() {
+        let metrics = TestMetrics()
+        MetricsSystem.bootstrapInternal(metrics)
 
-        testSecondsTimer.preferDisplayUnit(.microseconds)
-        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1_000_000, "expected value to match")
+        let value = Int64.random(in: 0 ... 1000)
+        let timer = Timer(label: "test", preferredDisplayUnit: .seconds)
+        timer.recordSeconds(value)
 
-        testSecondsTimer.preferDisplayUnit(.nanoseconds)
-        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1_000_000_000, "expected value to match")
+        let testTimer = timer.handler as! TestTimer
+
+        testTimer.preferDisplayUnit(.nanoseconds)
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000 * 1000, "expected value to match")
+
+        testTimer.preferDisplayUnit(.microseconds)
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000, "expected value to match")
+
+        testTimer.preferDisplayUnit(.milliseconds)
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000, "expected value to match")
+
+        testTimer.preferDisplayUnit(.seconds)
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value, "expected value to match")
+
+        testTimer.preferDisplayUnit(.minutes)
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 60, "expected value to match")
+
+        testTimer.preferDisplayUnit(.hours)
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 60 * 60, "expected value to match")
+
+        testTimer.preferDisplayUnit(.days)
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 60 * 60 * 24, "expected value to match")
     }
 }
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -100,7 +100,6 @@ class MetricsExtensionsTests: XCTestCase {
 
         let testSecondsTimer = secondsTimer.handler as! TestTimer
         XCTAssertEqual(testSecondsTimer.values.count, 1, "expected number of entries to match")
-        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 2, "timer should have been stored")
     }
 
@@ -108,32 +107,32 @@ class MetricsExtensionsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
 
-        let value = Int64.random(in: 0 ... 1000)
+        let value = Double.random(in: 0 ... 1000)
         let timer = Timer(label: "test", preferredDisplayUnit: .seconds)
         timer.recordSeconds(value)
 
         let testTimer = timer.handler as! TestTimer
 
         testTimer.preferDisplayUnit(.nanoseconds)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000 * 1000, "expected value to match")
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000 * 1000, accuracy: 1.0, "expected value to match")
 
         testTimer.preferDisplayUnit(.microseconds)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000, "expected value to match")
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000, accuracy: 0.001, "expected value to match")
 
         testTimer.preferDisplayUnit(.milliseconds)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000, "expected value to match")
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000, accuracy: 0.000001, "expected value to match")
 
         testTimer.preferDisplayUnit(.seconds)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value, "expected value to match")
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value, accuracy: 0.000000001, "expected value to match")
 
         testTimer.preferDisplayUnit(.minutes)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 60, "expected value to match")
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value / 60, accuracy: 0.000000001, "expected value to match")
 
         testTimer.preferDisplayUnit(.hours)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 60 * 60, "expected value to match")
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value / (60 * 60), accuracy: 0.000000001, "expected value to match")
 
         testTimer.preferDisplayUnit(.days)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 60 * 60 * 24, "expected value to match")
+        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value / (60 * 60 * 24), accuracy: 0.000000001, "expected value to match")
     }
 }
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -102,6 +102,15 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testSecondsTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 2, "timer should have been stored")
+
+        testSecondsTimer.preferDisplayUnit(.milliseconds)
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000, "expected value to match")
+
+        testSecondsTimer.preferDisplayUnit(.microseconds)
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000_000, "expected value to match")
+
+        testSecondsTimer.preferDisplayUnit(.nanoseconds)
+        XCTAssertEqual(testSecondsTimer.retriveValueInPreferredUnit(atIndex: 0), secondsValue * 1000_000_000, "expected value to match")
     }
 }
 

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -166,6 +166,7 @@ internal class TestTimer: TimerHandler, Equatable {
             case .minutes: return (value / 1_000_000_000) * 60
             case .seconds: return value / 1_000_000_000
             case .milliseconds: return value / 1_000_000
+            case .microseconds: return value / 1_000
             case .nanoseconds: return value
             }
         }

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -166,7 +166,7 @@ internal class TestTimer: TimerHandler, Equatable {
             case .minutes: return (value / 1_000_000_000) * 60
             case .seconds: return value / 1_000_000_000
             case .milliseconds: return value / 1_000_000
-            case .microseconds: return value / 1_000
+            case .microseconds: return value / 1000
             case .nanoseconds: return value
             }
         }

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -154,22 +154,13 @@ internal class TestTimer: TimerHandler, Equatable {
         }
     }
 
-    func retriveValueInPreferredUnit(atIndex i: Int) -> Int64 {
+    func retriveValueInPreferredUnit(atIndex i: Int) -> Double {
         return self.lock.withLock {
             let value = values[i].1
             guard let displayUnit = self.displayUnit else {
-                return value
+                return Double(value)
             }
-            switch displayUnit {
-            case .days: return (value / 1_000_000_000) * 60 * 60 * 24
-            case .hours: return (value / 1_000_000_000) * 60 * 60
-            case .minutes: return (value / 1_000_000_000) * 60
-            case .seconds: return value / 1_000_000_000
-            case .milliseconds: return value / 1_000_000
-            case .microseconds: return value / 1000
-            case .nanoseconds: return value
-            default: preconditionFailure("unknown display unit: \(displayUnit)")
-            }
+            return Double(value) / Double(displayUnit.scaleFromNanoseconds)
         }
     }
 

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -168,6 +168,7 @@ internal class TestTimer: TimerHandler, Equatable {
             case .milliseconds: return value / 1_000_000
             case .microseconds: return value / 1000
             case .nanoseconds: return value
+            default: preconditionFailure("unknown display unit: \(displayUnit)")
             }
         }
     }


### PR DESCRIPTION
Motivation:

I have a metrics backend where I need to store timer values in
microseconds. The "preferred display unit" models this exactly, but it
seems to have (inadvertently?) omitted the possibility to express
microseconds. Note that among the timer "report" methods there is
already a microseconds option.

Modifications:

adding an emum case is an API breaking change. so instead of just adding the enum case for microseconds, we use this opportunity to change `TimeUnit` from enum to struct so that we can add more cases in the future without breaking the API. 
