### PR TITLE
+metrics should include their labels when printed to ease debugging

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -84,6 +84,12 @@ public class Counter {
     }
 }
 
+extension Counter: CustomStringConvertible {
+    public var description: String {
+        "Counter(\(self.label), dimensions: \(self.dimensions))"
+    }
+}
+
 public extension Recorder {
     /// Create a new `Recorder`.
     ///
@@ -155,6 +161,12 @@ public class Recorder {
     @inlinable
     public func record<DataType: BinaryFloatingPoint>(_ value: DataType) {
         self.handler.record(Double(value))
+    }
+}
+
+extension Recorder: CustomStringConvertible {
+    public var description: String {
+        "\(Self.self)(\(self.label), dimensions: \(self.dimensions), aggregate: \(self.aggregate))"
     }
 }
 
@@ -353,6 +365,12 @@ public class Timer {
     @inlinable
     public func recordSeconds<DataType: BinaryFloatingPoint>(_ duration: DataType) {
         self.recordNanoseconds(Double(duration * 1_000_000_000) < Double(Int64.max) ? Int64(duration * 1_000_000_000) : Int64.max)
+    }
+}
+
+extension Timer: CustomStringConvertible {
+    public var description: String {
+        "Timer(\(self.label), dimensions: \(self.dimensions))"
     }
 }
 

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -86,7 +86,7 @@ public class Counter {
 
 extension Counter: CustomStringConvertible {
     public var description: String {
-        "Counter(\(self.label), dimensions: \(self.dimensions))"
+        return "Counter(\(self.label), dimensions: \(self.dimensions))"
     }
 }
 
@@ -166,7 +166,7 @@ public class Recorder {
 
 extension Recorder: CustomStringConvertible {
     public var description: String {
-        "\(Self.self)(\(self.label), dimensions: \(self.dimensions), aggregate: \(self.aggregate))"
+        return "\(Self.self)(\(self.label), dimensions: \(self.dimensions), aggregate: \(self.aggregate))"
     }
 }
 
@@ -370,7 +370,7 @@ public class Timer {
 
 extension Timer: CustomStringConvertible {
     public var description: String {
-        "Timer(\(self.label), dimensions: \(self.dimensions))"
+        return "Timer(\(self.label), dimensions: \(self.dimensions))"
     }
 }
 

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -166,7 +166,7 @@ public class Recorder {
 
 extension Recorder: CustomStringConvertible {
     public var description: String {
-        return "\(Self.self)(\(self.label), dimensions: \(self.dimensions), aggregate: \(self.aggregate))"
+        return "\(type(of: self))(\(self.label), dimensions: \(self.dimensions), aggregate: \(self.aggregate))"
     }
 }
 

--- a/Tests/MetricsTests/CoreMetricsTests+XCTest.swift
+++ b/Tests/MetricsTests/CoreMetricsTests+XCTest.swift
@@ -43,6 +43,7 @@ extension MetricsTests {
             ("testDestroyingGauge", testDestroyingGauge),
             ("testDestroyingCounter", testDestroyingCounter),
             ("testDestroyingTimer", testDestroyingTimer),
+            ("testDescriptions", testDescriptions),
         ]
     }
 }

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -391,4 +391,21 @@ class MetricsTests: XCTestCase {
         let identityAgain = ObjectIdentifier(timerAgain)
         XCTAssertNotEqual(identity, identityAgain, "since the cached metric was released, the created a new should have a different identity")
     }
+
+    func testDescriptions() throws {
+        let metrics = TestMetrics()
+        MetricsSystem.bootstrapInternal(metrics)
+
+        let timer = Timer(label: "hello.timer")
+        XCTAssertEqual("\(timer)", "Timer(hello.timer, dimensions: [])")
+
+        let counter = Counter(label: "hello.counter")
+        XCTAssertEqual("\(counter)", "Counter(hello.counter, dimensions: [])")
+
+        let gauge = Gauge(label: "hello.gauge")
+        XCTAssertEqual("\(gauge)", "Gauge(hello.gauge, dimensions: [], aggregate: false)")
+
+        let recorder = Recorder(label: "hello.recorder")
+        XCTAssertEqual("\(recorder)", "Recorder(hello.recorder, dimensions: [], aggregate: true)")
+    }
 }


### PR DESCRIPTION
### Motivation:

In some situations one may have a Timer in hand but be unsure if that's the "right one" if developing a library or framework where metrics object creation is a bit smarter than manually ad hoc created.

It is useful to be able to print what labels a metric represents.

### Modifications:

- better description impls

### Result:

- easier to debug swift-metrics in advanced use cases