### PR TITLE
Add Timer.recordInterval method

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -368,15 +368,6 @@ public class Timer {
     public func recordSeconds<DataType: BinaryFloatingPoint>(_ duration: DataType) {
         self.recordNanoseconds(Double(duration * 1_000_000_000) < Double(Int64.max) ? Int64(duration * 1_000_000_000) : Int64.max)
     }
-
-    /// Record the time interval (with nanosecond precision) between the passed `since` dispatch time and `end` dispatch time.
-    ///
-    /// - parameters:
-    ///   - since: Start of the interval as `DispatchTime`.
-    ///   - end: End of the interval, defaulting to `.now()`.
-    public func recordInterval(since: DispatchTime, end: DispatchTime = .now()) {
-        self.recordNanoseconds(end.uptimeNanoseconds - since.uptimeNanoseconds)
-    }
 }
 
 extension Timer: CustomStringConvertible {

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
+
 // MARK: User API
 
 extension Counter {
@@ -365,6 +367,15 @@ public class Timer {
     @inlinable
     public func recordSeconds<DataType: BinaryFloatingPoint>(_ duration: DataType) {
         self.recordNanoseconds(Double(duration * 1_000_000_000) < Double(Int64.max) ? Int64(duration * 1_000_000_000) : Int64.max)
+    }
+
+    /// Record the time interval between the passed `since` dispatch time and `end` dispatch time.
+    ///
+    /// - parameters:
+    ///   - since: Start of the interval as `DispatchTime`.
+    ///   - end: End of the interval, defaulting to `.now()`.
+    public func recordInterval(since: DispatchTime, end: DispatchTime = .now()) {
+        self.recordNanoseconds(end.uptimeNanoseconds - since.uptimeNanoseconds)
     }
 }
 

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -369,7 +369,7 @@ public class Timer {
         self.recordNanoseconds(Double(duration * 1_000_000_000) < Double(Int64.max) ? Int64(duration * 1_000_000_000) : Int64.max)
     }
 
-    /// Record the time interval between the passed `since` dispatch time and `end` dispatch time.
+    /// Record the time interval (with nanosecond precision) between the passed `since` dispatch time and `end` dispatch time.
     ///
     /// - parameters:
     ///   - since: Start of the interval as `DispatchTime`.

--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -33,6 +33,15 @@ public extension Timer {
         }
         return try body()
     }
+
+    /// Record the time interval (with nanosecond precision) between the passed `since` dispatch time and `end` dispatch time.
+    ///
+    /// - parameters:
+    ///   - since: Start of the interval as `DispatchTime`.
+    ///   - end: End of the interval, defaulting to `.now()`.
+    func recordInterval(since: DispatchTime, end: DispatchTime = .now()) {
+        self.recordNanoseconds(end.uptimeNanoseconds - since.uptimeNanoseconds)
+    }
 }
 
 public extension Timer {

--- a/Tests/MetricsTests/MetricsTests+XCTest.swift
+++ b/Tests/MetricsTests/MetricsTests+XCTest.swift
@@ -28,6 +28,7 @@ extension MetricsExtensionsTests {
             ("testTimerBlock", testTimerBlock),
             ("testTimerWithTimeInterval", testTimerWithTimeInterval),
             ("testTimerWithDispatchTime", testTimerWithDispatchTime),
+            ("testTimerWithDispatchTimeInterval", testTimerWithDispatchTimeInterval),
             ("testTimerUnits", testTimerUnits),
             ("testPreferDisplayUnit", testPreferDisplayUnit),
         ]

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -78,6 +78,23 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testTimer.values[4].1, 0, "expected value to match")
     }
 
+    func testTimerWithDispatchTimeInterval() {
+        let metrics = TestMetrics()
+        MetricsSystem.bootstrapInternal(metrics)
+
+        let name = "timer-\(UUID().uuidString)"
+
+        let timer = Timer(label: name)
+        let start = DispatchTime.now()
+        let end = DispatchTime(uptimeNanoseconds: start.uptimeNanoseconds + 1000 * 1000 * 1000)
+        timer.recordInterval(since: start, end: end)
+
+        let testTimer = timer.handler as! TestTimer
+        XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
+        XCTAssertEqual(UInt64(testTimer.values.first!.1), end.uptimeNanoseconds - start.uptimeNanoseconds, "expected value to match")
+        XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
+    }
+
     func testTimerUnits() throws {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)


### PR DESCRIPTION
Add a method to `Timer` allowing to record the difference between a given start `DispatchTime` and a given end `DispatchTime`, defaulting to `.now()`.

### Motivation:

I agree with the reasoning @ktoso provided  in #79 

### Modifications:

- Added `Timer.recordInterval` method
- Added unit test for `Timer.recordInterval`

### Result:

Users recording the difference between a past timestamp and "now" will be able to simplify their code by writing:

```swift
timer.recordInterval(since: start)
```

---

Closes #79