### PR TITLE
Introduce FloatingPointCounter

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -12,10 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// MARK: Testing API
-
-internal var _enableAssertions = true
-
 // MARK: User API
 
 extension Counter {
@@ -596,29 +592,18 @@ internal class AccumulatingRoundingFloatingPointCounter: FloatingPointCounterHan
     }
 
     func increment(by amount: Double) {
-        // Drop values in illegal values (Asserting in debug builds)
-        guard !amount.isNaN else {
-            assert(!_enableAssertions, "cannot increment by NaN")
-            return
-        }
+        // Drop illegal values
+        // - cannot increment by NaN
+        guard !amount.isNaN else { return }
+        // - cannot increment by infinite quantities
+        guard !amount.isInfinite else { return }
+        // - cannot increment by negative values
+        guard amount.sign == .plus else { return }
+        // - cannot increment by zero
+        guard !amount.isZero else { return }
 
-        guard !amount.isInfinite else {
-            assert(!_enableAssertions, "cannot increment by infinite quantities")
-            return
-        }
-
-        guard amount.sign == .plus else {
-            assert(!_enableAssertions, "cannot increment by negative values")
-            return
-        }
-
-        guard !amount.isZero else {
-            return
-        }
-
-        // If amount is in Int64.max..<+Inf
         if amount.exponent >= 63 {
-            // Ceil to Int64.max
+            // If amount is in Int64.max..<+Inf, ceil to Int64.max
             self.lock.withLockVoid {
                 self.counterHandler.increment(by: .max)
             }

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -111,7 +111,7 @@ extension FloatingPointCounter {
 
 /// A FloatingPointCounter is a cumulative metric that represents a single monotonically increasing FloatingPointCounter whose value can only increase or be reset to zero.
 /// For example, you can use a FloatingPointCounter to represent the number of requests served, tasks completed, or errors.
-/// FloatingPointCounter is not supported by all metrics backends, however a default implementation is provided which accumulates floating point increments and records increments to a standard Counter after crossing integer boundaries.
+/// FloatingPointCounter is not supported by all metrics backends, however a default implementation is provided which accumulates floating point values and records increments to a standard Counter after crossing integer boundaries.
 ///
 /// This is the user-facing FloatingPointCounter API.
 ///
@@ -648,7 +648,7 @@ internal class AccumulatingRoundingFloatingPointCounter: FloatingPointCounterHan
 extension MetricsFactory {
     /// Create a default backing `FloatingPointCounterHandler` for backends which do not naively support floating point counters.
     ///
-    /// The created FloatingPointCounterHandler is a wrapper around a backend's CounterHandler which accumulates floating point increments and records increments to an underlying CounterHandler after crossing integer boundaries.
+    /// The created FloatingPointCounterHandler is a wrapper around a backend's CounterHandler which accumulates floating point values and records increments to an underlying CounterHandler after crossing integer boundaries.
     ///
     /// - parameters:
     ///     - label: The label for the `FloatingPointCounterHandler`.

--- a/Tests/MetricsTests/CoreMetricsTests+XCTest.swift
+++ b/Tests/MetricsTests/CoreMetricsTests+XCTest.swift
@@ -27,6 +27,12 @@ extension MetricsTests {
         return [
             ("testCounters", testCounters),
             ("testCounterBlock", testCounterBlock),
+            ("testDefaultFloatingPointCounter_ignoresNan", testDefaultFloatingPointCounter_ignoresNan),
+            ("testDefaultFloatingPointCounter_ignoresInfinity", testDefaultFloatingPointCounter_ignoresInfinity),
+            ("testDefaultFloatingPointCounter_ignoresNegativeValues", testDefaultFloatingPointCounter_ignoresNegativeValues),
+            ("testDefaultFloatingPointCounter_ignoresZero", testDefaultFloatingPointCounter_ignoresZero),
+            ("testDefaultFloatingPointCounter_ceilsExtremeValues", testDefaultFloatingPointCounter_ceilsExtremeValues),
+            ("testDefaultFloatingPointCounter_accumulatesFloatingPointDecimalValues", testDefaultFloatingPointCounter_accumulatesFloatingPointDecimalValues),
             ("testRecorders", testRecorders),
             ("testRecordersInt", testRecordersInt),
             ("testRecordersFloat", testRecordersFloat),

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -57,63 +57,47 @@ class MetricsTests: XCTestCase {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
-        // disable assertions to test fallback path
-        _enableAssertions = false
         let label = "\(#function)-fp-counter-\(UUID())"
         let fpCounter = FloatingPointCounter(label: label)
         let counter = metrics.counters[label] as! TestCounter
         fpCounter.increment(by: Double.nan)
         fpCounter.increment(by: Double.signalingNaN)
         XCTAssertEqual(counter.values.count, 0, "expected nan values to be ignored")
-        // reenable assertions
-        _enableAssertions = true
     }
 
     func testDefaultFloatingPointCounter_ignoresInfinity() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
-        // disable assertions to test fallback path
-        _enableAssertions = false
         let label = "\(#function)-fp-counter-\(UUID())"
         let fpCounter = FloatingPointCounter(label: label)
         let counter = metrics.counters[label] as! TestCounter
         fpCounter.increment(by: Double.infinity)
         fpCounter.increment(by: -Double.infinity)
         XCTAssertEqual(counter.values.count, 0, "expected infinite values to be ignored")
-        // reenable assertions
-        _enableAssertions = true
     }
 
     func testDefaultFloatingPointCounter_ignoresNegativeValues() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
-        // disable assertions to test fallback path
-        _enableAssertions = false
         let label = "\(#function)-fp-counter-\(UUID())"
         let fpCounter = FloatingPointCounter(label: label)
         let counter = metrics.counters[label] as! TestCounter
         fpCounter.increment(by: -100)
         XCTAssertEqual(counter.values.count, 0, "expected negative values to be ignored")
-        // reenable assertions
-        _enableAssertions = true
     }
 
     func testDefaultFloatingPointCounter_ignoresZero() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
-        // disable assertions to test fallback path
-        _enableAssertions = false
         let label = "\(#function)-fp-counter-\(UUID())"
         let fpCounter = FloatingPointCounter(label: label)
         let counter = metrics.counters[label] as! TestCounter
         fpCounter.increment(by: 0)
         fpCounter.increment(by: -0)
         XCTAssertEqual(counter.values.count, 0, "expected zero values to be ignored")
-        // reenable assertions
-        _enableAssertions = true
     }
 
     func testDefaultFloatingPointCounter_ceilsExtremeValues() {

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -131,25 +131,25 @@ class MetricsExtensionsTests: XCTestCase {
         let testTimer = timer.handler as! TestTimer
 
         testTimer.preferDisplayUnit(.nanoseconds)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000 * 1000, accuracy: 1.0, "expected value to match")
+        XCTAssertEqual(testTimer.retrieveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000 * 1000, accuracy: 1.0, "expected value to match")
 
         testTimer.preferDisplayUnit(.microseconds)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000, accuracy: 0.001, "expected value to match")
+        XCTAssertEqual(testTimer.retrieveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000, accuracy: 0.001, "expected value to match")
 
         testTimer.preferDisplayUnit(.milliseconds)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value * 1000, accuracy: 0.000001, "expected value to match")
+        XCTAssertEqual(testTimer.retrieveValueInPreferredUnit(atIndex: 0), value * 1000, accuracy: 0.000001, "expected value to match")
 
         testTimer.preferDisplayUnit(.seconds)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value, accuracy: 0.000000001, "expected value to match")
+        XCTAssertEqual(testTimer.retrieveValueInPreferredUnit(atIndex: 0), value, accuracy: 0.000000001, "expected value to match")
 
         testTimer.preferDisplayUnit(.minutes)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value / 60, accuracy: 0.000000001, "expected value to match")
+        XCTAssertEqual(testTimer.retrieveValueInPreferredUnit(atIndex: 0), value / 60, accuracy: 0.000000001, "expected value to match")
 
         testTimer.preferDisplayUnit(.hours)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value / (60 * 60), accuracy: 0.000000001, "expected value to match")
+        XCTAssertEqual(testTimer.retrieveValueInPreferredUnit(atIndex: 0), value / (60 * 60), accuracy: 0.000000001, "expected value to match")
 
         testTimer.preferDisplayUnit(.days)
-        XCTAssertEqual(testTimer.retriveValueInPreferredUnit(atIndex: 0), value / (60 * 60 * 24), accuracy: 0.000000001, "expected value to match")
+        XCTAssertEqual(testTimer.retrieveValueInPreferredUnit(atIndex: 0), value / (60 * 60 * 24), accuracy: 0.000000001, "expected value to match")
     }
 }
 

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -24,18 +24,18 @@ internal final class TestMetrics: MetricsFactory {
     var recorders = [String: RecorderHandler]()
     var timers = [String: TimerHandler]()
 
-    public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+    func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
         return self.make(label: label, dimensions: dimensions, registry: &self.counters, maker: TestCounter.init)
     }
 
-    public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
+    func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
         let maker = { (label: String, dimensions: [(String, String)]) -> RecorderHandler in
             TestRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
         }
         return self.make(label: label, dimensions: dimensions, registry: &self.recorders, maker: maker)
     }
 
-    public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
+    func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
         return self.make(label: label, dimensions: dimensions, registry: &self.timers, maker: TestTimer.init)
     }
 
@@ -154,7 +154,7 @@ internal class TestTimer: TimerHandler, Equatable {
         }
     }
 
-    func retriveValueInPreferredUnit(atIndex i: Int) -> Double {
+    func retrieveValueInPreferredUnit(atIndex i: Int) -> Double {
         return self.lock.withLock {
             let value = values[i].1
             guard let displayUnit = self.displayUnit else {
@@ -171,7 +171,7 @@ internal class TestTimer: TimerHandler, Equatable {
         print("recording \(duration) \(self.label)")
     }
 
-    public static func == (lhs: TestTimer, rhs: TestTimer) -> Bool {
+    static func == (lhs: TestTimer, rhs: TestTimer) -> Bool {
         return lhs.id == rhs.id
     }
 }


### PR DESCRIPTION
Introduce FloatingPointCounter.

### Motivation:

It is not currently possible to record floating point values via the swift-metrics API even if the metrics backend supports it.

### Modifications:

Adds a `FloatingPointCounter` type to allow users to accumulate non-integral metrics backed by a `FloatingPointCounterHandler`. Introduces a default implementation for creating and destroying `FloatingPointCounterHandler`s for metric backends that do not natively support floating point counters.

On such backends, `FloatingPointCounter` is backed by a `AccumulatingRoundingFloatingPointCounter` which accumulates floating point values internally and record increments to a wrapped `CounterHandler` after crossing integer boundaries.

### Result:

Users can create `FloatingPointCounter`s to record floating point values and get enhanced behavior for backends that support floating point values.
