### PR TITLE
Add 5.6 nightly CI

### DIFF
--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-metrics:20.04-5.6
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.6-focal"
+
+  test:
+    image: swift-metrics:20.04-5.6
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: swift-metrics:20.04-5.6


### PR DESCRIPTION
The 5.6 nightly images are avaialable, let's use them.

@tomerd Can you add a 5.6 builder here?