### PR TITLE
Update swift tools version to 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.5
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Metrics API open source project


### PR DESCRIPTION

### Motivation:
Xcode warning 
**Conversion to Swift 5 is available**

### Modifications:
package.swift

Update swift tools version
### Result:
No warnings in Xcode when using SPM

