### PR TITLE
Expose `MetricsTestKit` as a product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
     products: [
         .library(name: "CoreMetrics", targets: ["CoreMetrics"]),
         .library(name: "Metrics", targets: ["Metrics"]),
+        .library(name: "MetricsTestKit", targets: ["MetricsTestKit"]),
     ],
     targets: [
         .target(


### PR DESCRIPTION
For adopters to use `MetricsTestKit` it must be exposed as a product.