### PR TITLE
Remove testable import from TestMetrics.

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -31,7 +31,7 @@ extension Counter {
     /// In response the library MAY decide to eagerly release any resources held by this `Counter`.
     @inlinable
     public func destroy() {
-        MetricsSystem.factory.destroyCounter(self.handler)
+        MetricsSystem.factory.destroyCounter(self._handler)
     }
 }
 
@@ -42,8 +42,8 @@ extension Counter {
 ///
 /// Its behavior depends on the `CounterHandler` implementation.
 public final class Counter {
-    @usableFromInline
-    let handler: CounterHandler
+    /// ``_handler`` is only public to allow access from `MetricsTestKit`. Do not consider it part of the public API.
+    public let _handler: CounterHandler
     public let label: String
     public let dimensions: [(String, String)]
 
@@ -61,7 +61,7 @@ public final class Counter {
     public init(label: String, dimensions: [(String, String)], handler: CounterHandler) {
         self.label = label
         self.dimensions = dimensions
-        self.handler = handler
+        self._handler = handler
     }
 
     /// Increment the counter.
@@ -70,7 +70,7 @@ public final class Counter {
     ///     - by: Amount to increment by.
     @inlinable
     public func increment<DataType: BinaryInteger>(by amount: DataType) {
-        self.handler.increment(by: Int64(amount))
+        self._handler.increment(by: Int64(amount))
     }
 
     /// Increment the counter by one.
@@ -82,7 +82,7 @@ public final class Counter {
     /// Reset the counter back to zero.
     @inlinable
     public func reset() {
-        self.handler.reset()
+        self._handler.reset()
     }
 }
 
@@ -109,7 +109,7 @@ extension FloatingPointCounter {
     /// In response the library MAY decide to eagerly release any resources held by this `FloatingPointCounter`.
     @inlinable
     public func destroy() {
-        MetricsSystem.factory.destroyFloatingPointCounter(self.handler)
+        MetricsSystem.factory.destroyFloatingPointCounter(self._handler)
     }
 }
 
@@ -121,8 +121,8 @@ extension FloatingPointCounter {
 ///
 /// Its behavior depends on the `FloatingCounterHandler` implementation.
 public final class FloatingPointCounter {
-    @usableFromInline
-    let handler: FloatingPointCounterHandler
+    /// ``_handler`` is only public to allow access from `MetricsTestKit`. Do not consider it part of the public API.
+    public let _handler: FloatingPointCounterHandler
     public let label: String
     public let dimensions: [(String, String)]
 
@@ -140,7 +140,7 @@ public final class FloatingPointCounter {
     public init(label: String, dimensions: [(String, String)], handler: FloatingPointCounterHandler) {
         self.label = label
         self.dimensions = dimensions
-        self.handler = handler
+        self._handler = handler
     }
 
     /// Increment the FloatingPointCounter.
@@ -149,7 +149,7 @@ public final class FloatingPointCounter {
     ///     - by: Amount to increment by.
     @inlinable
     public func increment<DataType: BinaryFloatingPoint>(by amount: DataType) {
-        self.handler.increment(by: Double(amount))
+        self._handler.increment(by: Double(amount))
     }
 
     /// Increment the FloatingPointCounter by one.
@@ -161,7 +161,7 @@ public final class FloatingPointCounter {
     /// Reset the FloatingPointCounter back to zero.
     @inlinable
     public func reset() {
-        self.handler.reset()
+        self._handler.reset()
     }
 }
 
@@ -188,7 +188,7 @@ extension Recorder {
     /// In response the library MAY decide to eagerly release any resources held by this `Recorder`.
     @inlinable
     public func destroy() {
-        MetricsSystem.factory.destroyRecorder(self.handler)
+        MetricsSystem.factory.destroyRecorder(self._handler)
     }
 }
 
@@ -198,8 +198,8 @@ extension Recorder {
 ///
 /// Its behavior depends on the `RecorderHandler` implementation.
 public class Recorder {
-    @usableFromInline
-    let handler: RecorderHandler
+    /// ``_handler`` is only public to allow access from `MetricsTestKit`. Do not consider it part of the public API.
+    public let _handler: RecorderHandler
     public let label: String
     public let dimensions: [(String, String)]
     public let aggregate: Bool
@@ -219,7 +219,7 @@ public class Recorder {
         self.label = label
         self.dimensions = dimensions
         self.aggregate = aggregate
-        self.handler = handler
+        self._handler = handler
     }
 
     /// Record a value.
@@ -231,7 +231,7 @@ public class Recorder {
     ///     - value: Value to record.
     @inlinable
     public func record<DataType: BinaryInteger>(_ value: DataType) {
-        self.handler.record(Int64(value))
+        self._handler.record(Int64(value))
     }
 
     /// Record a value.
@@ -243,7 +243,7 @@ public class Recorder {
     ///     - value: Value to record.
     @inlinable
     public func record<DataType: BinaryFloatingPoint>(_ value: DataType) {
-        self.handler.record(Double(value))
+        self._handler.record(Double(value))
     }
 }
 
@@ -328,7 +328,7 @@ public extension Timer {
     /// In response the library MAY decide to eagerly release any resources held by this `Timer`.
     @inlinable
     func destroy() {
-        MetricsSystem.factory.destroyTimer(self.handler)
+        MetricsSystem.factory.destroyTimer(self._handler)
     }
 }
 
@@ -339,8 +339,8 @@ public extension Timer {
 ///
 /// Its behavior depends on the `TimerHandler` implementation.
 public final class Timer {
-    @usableFromInline
-    let handler: TimerHandler
+    /// ``_handler`` is only public to allow access from `MetricsTestKit`. Do not consider it part of the public API.
+    public let _handler: TimerHandler
     public let label: String
     public let dimensions: [(String, String)]
 
@@ -358,7 +358,7 @@ public final class Timer {
     public init(label: String, dimensions: [(String, String)], handler: TimerHandler) {
         self.label = label
         self.dimensions = dimensions
-        self.handler = handler
+        self._handler = handler
     }
 
     /// Record a duration in nanoseconds.
@@ -367,7 +367,7 @@ public final class Timer {
     ///     - value: Duration to record.
     @inlinable
     public func recordNanoseconds(_ duration: Int64) {
-        self.handler.recordNanoseconds(duration)
+        self._handler.recordNanoseconds(duration)
     }
 
     /// Record a duration in nanoseconds.

--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -25,7 +25,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import CoreMetrics
+import CoreMetrics
 import Metrics
 import XCTest
 
@@ -145,8 +145,8 @@ extension TestMetrics {
     // MARK: - Counter
 
     public func expectCounter(_ metric: Counter) throws -> TestCounter {
-        guard let counter = metric.handler as? TestCounter else {
-            throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestCounter.self)")
+        guard let counter = metric._handler as? TestCounter else {
+            throw TestMetricsError.illegalMetricType(metric: metric._handler, expected: "\(TestCounter.self)")
         }
         return counter
     }
@@ -177,8 +177,8 @@ extension TestMetrics {
     // MARK: - Recorder
 
     public func expectRecorder(_ metric: Recorder) throws -> TestRecorder {
-        guard let recorder = metric.handler as? TestRecorder else {
-            throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestRecorder.self)")
+        guard let recorder = metric._handler as? TestRecorder else {
+            throw TestMetricsError.illegalMetricType(metric: metric._handler, expected: "\(TestRecorder.self)")
         }
         return recorder
     }
@@ -199,8 +199,8 @@ extension TestMetrics {
     // MARK: - Timer
 
     public func expectTimer(_ metric: CoreMetrics.Timer) throws -> TestTimer {
-        guard let timer = metric.handler as? TestTimer else {
-            throw TestMetricsError.illegalMetricType(metric: metric.handler, expected: "\(TestTimer.self)")
+        guard let timer = metric._handler as? TestTimer else {
+            throw TestMetricsError.illegalMetricType(metric: metric._handler, expected: "\(TestTimer.self)")
         }
         return timer
     }

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -23,7 +23,7 @@ class MetricsTests: XCTestCase {
         let group = DispatchGroup()
         let name = "counter-\(NSUUID().uuidString)"
         let counter = Counter(label: name)
-        let testCounter = counter.handler as! TestCounter
+        let testCounter = counter._handler as! TestCounter
         let total = Int.random(in: 500 ... 1000)
         for _ in 0 ... total {
             group.enter()
@@ -122,7 +122,7 @@ class MetricsTests: XCTestCase {
         MetricsSystem.bootstrapInternal(metrics)
         let label = "\(#function)-fp-counter-\(UUID())"
         let fpCounter = FloatingPointCounter(label: label)
-        let rawFpCounter = fpCounter.handler as! AccumulatingRoundingFloatingPointCounter
+        let rawFpCounter = fpCounter._handler as! AccumulatingRoundingFloatingPointCounter
         let counter = metrics.counters[label] as! TestCounter
 
         // Increment by a small value (perfectly representable)
@@ -152,7 +152,7 @@ class MetricsTests: XCTestCase {
         let group = DispatchGroup()
         let name = "recorder-\(NSUUID().uuidString)"
         let recorder = Recorder(label: name)
-        let testRecorder = recorder.handler as! TestRecorder
+        let testRecorder = recorder._handler as! TestRecorder
         let total = Int.random(in: 500 ... 1000)
         for _ in 0 ... total {
             group.enter()
@@ -170,7 +170,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         let recorder = Recorder(label: "test-recorder")
-        let testRecorder = recorder.handler as! TestRecorder
+        let testRecorder = recorder._handler as! TestRecorder
         let values = (0 ... 999).map { _ in Int32.random(in: Int32.min ... Int32.max) }
         for i in 0 ... values.count - 1 {
             recorder.record(values[i])
@@ -186,7 +186,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         let recorder = Recorder(label: "test-recorder")
-        let testRecorder = recorder.handler as! TestRecorder
+        let testRecorder = recorder._handler as! TestRecorder
         let values = (0 ... 999).map { _ in Float.random(in: Float(Int32.min) ... Float(Int32.max)) }
         for i in 0 ... values.count - 1 {
             recorder.record(values[i])
@@ -217,7 +217,7 @@ class MetricsTests: XCTestCase {
         let group = DispatchGroup()
         let name = "timer-\(NSUUID().uuidString)"
         let timer = Timer(label: name)
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         let total = Int.random(in: 500 ... 1000)
         for _ in 0 ... total {
             group.enter()
@@ -249,7 +249,7 @@ class MetricsTests: XCTestCase {
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
         let timer = Timer(label: "test-timer")
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         // nano
         let nano = Int64.random(in: 0 ... 5)
         timer.recordNanoseconds(nano)
@@ -278,7 +278,7 @@ class MetricsTests: XCTestCase {
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
         let timer = Timer(label: "test-timer")
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         // nano (integer)
         timer.recordNanoseconds(Int64.max)
         XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
@@ -315,7 +315,7 @@ class MetricsTests: XCTestCase {
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
         let timer = Timer(label: "test-timer")
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         // nano
         timer.recordNanoseconds(UInt64.max)
         XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
@@ -343,7 +343,7 @@ class MetricsTests: XCTestCase {
         let value = Double.random(in: -1000 ... 1000)
         let gauge = Gauge(label: name)
         gauge.record(value)
-        let recorder = gauge.handler as! TestRecorder
+        let recorder = gauge._handler as! TestRecorder
         XCTAssertEqual(recorder.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(recorder.values[0].1, value, "expected value to match")
     }
@@ -390,9 +390,9 @@ class MetricsTests: XCTestCase {
         }
 
         let counter1 = Counter(label: "foo")
-        XCTAssertFalse(counter1.handler is CustomHandler, "expected non-custom log handler")
+        XCTAssertFalse(counter1._handler is CustomHandler, "expected non-custom log handler")
         let counter2 = Counter(label: "foo", dimensions: [], handler: CustomHandler())
-        XCTAssertTrue(counter2.handler is CustomHandler, "expected custom log handler")
+        XCTAssertTrue(counter2._handler is CustomHandler, "expected custom log handler")
     }
 
     func testDestroyingGauge() throws {
@@ -405,7 +405,7 @@ class MetricsTests: XCTestCase {
         let gauge = Gauge(label: name)
         gauge.record(value)
 
-        let recorder = gauge.handler as! TestRecorder
+        let recorder = gauge._handler as! TestRecorder
         XCTAssertEqual(recorder.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(recorder.values.first!.1, value, "expected value to match")
         XCTAssertEqual(metrics.recorders.count, 1, "recorder should have been stored")
@@ -417,7 +417,7 @@ class MetricsTests: XCTestCase {
         let gaugeAgain = Gauge(label: name)
         gaugeAgain.record(-value)
 
-        let recorderAgain = gaugeAgain.handler as! TestRecorder
+        let recorderAgain = gaugeAgain._handler as! TestRecorder
         XCTAssertEqual(recorderAgain.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(recorderAgain.values.first!.1, -value, "expected value to match")
 
@@ -435,7 +435,7 @@ class MetricsTests: XCTestCase {
         let counter = Counter(label: name)
         counter.increment(by: value)
 
-        let testCounter = counter.handler as! TestCounter
+        let testCounter = counter._handler as! TestCounter
         XCTAssertEqual(testCounter.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testCounter.values.first!.1, Int64(value), "expected value to match")
         XCTAssertEqual(metrics.counters.count, 1, "counter should have been stored")
@@ -447,7 +447,7 @@ class MetricsTests: XCTestCase {
         let counterAgain = Counter(label: name)
         counterAgain.increment(by: value)
 
-        let testCounterAgain = counterAgain.handler as! TestCounter
+        let testCounterAgain = counterAgain._handler as! TestCounter
         XCTAssertEqual(testCounterAgain.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testCounterAgain.values.first!.1, Int64(value), "expected value to match")
 
@@ -465,7 +465,7 @@ class MetricsTests: XCTestCase {
         let timer = Timer(label: name)
         timer.recordNanoseconds(value)
 
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testTimer.values.first!.1, value, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
@@ -476,7 +476,7 @@ class MetricsTests: XCTestCase {
 
         let timerAgain = Timer(label: name)
         timerAgain.recordNanoseconds(value)
-        let testTimerAgain = timerAgain.handler as! TestTimer
+        let testTimerAgain = timerAgain._handler as! TestTimer
         XCTAssertEqual(testTimerAgain.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testTimerAgain.values.first!.1, value, "expected value to match")
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -38,7 +38,7 @@ class MetricsExtensionsTests: XCTestCase {
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
         let timer = Timer(label: "test-timer")
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         let timeInterval = TimeInterval(Double.random(in: 1 ... 500))
         timer.record(timeInterval)
         XCTAssertEqual(1, testTimer.values.count, "expected number of entries to match")
@@ -51,7 +51,7 @@ class MetricsExtensionsTests: XCTestCase {
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
         let timer = Timer(label: "test-timer")
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         // nano
         let nano = DispatchTimeInterval.nanoseconds(Int.random(in: 1 ... 500))
         timer.record(nano)
@@ -89,7 +89,7 @@ class MetricsExtensionsTests: XCTestCase {
         let end = DispatchTime(uptimeNanoseconds: start.uptimeNanoseconds + 1000 * 1000 * 1000)
         timer.recordInterval(since: start, end: end)
 
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(UInt64(testTimer.values.first!.1), end.uptimeNanoseconds - start.uptimeNanoseconds, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
@@ -105,7 +105,7 @@ class MetricsExtensionsTests: XCTestCase {
         let timer = Timer(label: name)
         timer.recordNanoseconds(value)
 
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
         XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testTimer.values.first!.1, value, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
@@ -115,7 +115,7 @@ class MetricsExtensionsTests: XCTestCase {
         let secondsTimer = Timer(label: secondsName, preferredDisplayUnit: .seconds)
         secondsTimer.recordSeconds(secondsValue)
 
-        let testSecondsTimer = secondsTimer.handler as! TestTimer
+        let testSecondsTimer = secondsTimer._handler as! TestTimer
         XCTAssertEqual(testSecondsTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(metrics.timers.count, 2, "timer should have been stored")
     }
@@ -128,7 +128,7 @@ class MetricsExtensionsTests: XCTestCase {
         let timer = Timer(label: "test", preferredDisplayUnit: .seconds)
         timer.recordSeconds(value)
 
-        let testTimer = timer.handler as! TestTimer
+        let testTimer = timer._handler as! TestTimer
 
         testTimer.preferDisplayUnit(.nanoseconds)
         XCTAssertEqual(testTimer.retrieveValueInPreferredUnit(atIndex: 0), value * 1000 * 1000 * 1000, accuracy: 1.0, "expected value to match")

--- a/Tests/MetricsTests/TestSendable.swift
+++ b/Tests/MetricsTests/TestSendable.swift
@@ -30,7 +30,7 @@ class SendableTest: XCTestCase {
 
             let task = Task.detached { () -> [Int64] in
                 counter.increment(by: value)
-                let handler = counter.handler as! TestCounter
+                let handler = counter._handler as! TestCounter
                 return handler.values.map { $0.1 }
             }
             let values = await task.value
@@ -45,7 +45,7 @@ class SendableTest: XCTestCase {
 
             let task = Task.detached { () -> Double in
                 counter.increment(by: value)
-                let handler = counter.handler as! AccumulatingRoundingFloatingPointCounter
+                let handler = counter._handler as! AccumulatingRoundingFloatingPointCounter
                 return handler.fraction
             }
             let fraction = await task.value
@@ -59,7 +59,7 @@ class SendableTest: XCTestCase {
 
             let task = Task.detached { () -> [Double] in
                 recorder.record(value)
-                let handler = recorder.handler as! TestRecorder
+                let handler = recorder._handler as! TestRecorder
                 return handler.values.map { $0.1 }
             }
             let values = await task.value
@@ -74,7 +74,7 @@ class SendableTest: XCTestCase {
 
             let task = Task.detached { () -> [Double] in
                 gauge.record(value)
-                let handler = gauge.handler as! TestRecorder
+                let handler = gauge._handler as! TestRecorder
                 return handler.values.map { $0.1 }
             }
             let values = await task.value
@@ -89,7 +89,7 @@ class SendableTest: XCTestCase {
 
             let task = Task.detached { () -> [Int64] in
                 timer.recordNanoseconds(value)
-                let handler = timer.handler as! TestTimer
+                let handler = timer._handler as! TestTimer
                 return handler.values.map { $0.1 }
             }
             let values = await task.value


### PR DESCRIPTION
Remove testable import from TestMetrics. Make `handler`s public, but ensure they are not part of the public API.

### Motivation:

Users may want to use `TestMetrics` in their own test utils that support more complex use cases. For this users should be able to compile `TestMetrics` with release settings. This is currently not possible since `TestMetrics` import `CoreMetrics` `@testable`.

`CoreMetrics` is imported `@testable` since we want to have access to the underlying `MetricHandlers`.

### Modifications:

- Make the handlers in the metrics public, but with an underscore to keep them out of the public API commitment
- Remove `@testable` from the `CoreMetrics` import in `TestMetrics `

### Result:

We can compile `TestMetrics` in release mode, without special compiler flags.
