### PR TITLE
Make `MetricsFactory` Sendable

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -555,7 +555,7 @@ public enum MetricsSystem {
 /// While some libraries may not need to implement this destroying as they may be stateless or similar,
 /// libraries using the metrics API should always assume a library WILL make use of this signal, and shall not
 /// neglect calling these methods when appropriate.
-public protocol MetricsFactory {
+public protocol MetricsFactory: _SwiftMetricsSendableProtocol {
     /// Create a backing `CounterHandler`.
     ///
     /// - parameters:


### PR DESCRIPTION
In #109, we likely forgot to require sendability for `MetricsFactory`. Given that `MetricsFactory` is accessed through the global `MetricsSystem.factory`, it clearly must be thread safe.

### Modifications

- Add sendability requirement to `MetricsFactory`

### Result:

`MetricsFactory` is sendable and I can remove `@preconcurrency` from my CoreMetric imports.
