### PR TITLE
Add Package.resolved to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .SourceKitten
 *.orig
 .swiftpm
+Package.resolved


### PR DESCRIPTION
This is a library target. Having a Package.resolved here doesn't make any sense (which is why we never commited it). To stop git from showing this file, we should add it to `.gitignore`.