### PR TITLE
Use UUID instead of NSUUID in MetricsTests

### DIFF
--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -243,7 +243,7 @@ public final class TestCounter: TestMetric, CounterHandler, Equatable {
     private var values = [(Date, Int64)]()
 
     init(label: String, dimensions: [(String, String)]) {
-        self.id = NSUUID().uuidString
+        self.id = UUID().uuidString
         self.label = label
         self.dimensions = dimensions
     }
@@ -297,7 +297,7 @@ public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
     private var values = [(Date, Double)]()
 
     init(label: String, dimensions: [(String, String)], aggregate: Bool) {
-        self.id = NSUUID().uuidString
+        self.id = UUID().uuidString
         self.label = label
         self.dimensions = dimensions
         self.aggregate = aggregate
@@ -345,7 +345,7 @@ public final class TestTimer: TestMetric, TimerHandler, Equatable {
     private var _values = [(Date, Int64)]()
 
     init(label: String, dimensions: [(String, String)]) {
-        self.id = NSUUID().uuidString
+        self.id = UUID().uuidString
         self.label = label
         self.displayUnit = nil
         self.dimensions = dimensions

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -21,7 +21,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         let group = DispatchGroup()
-        let name = "counter-\(NSUUID().uuidString)"
+        let name = "counter-\(UUID().uuidString)"
         let counter = Counter(label: name)
         let testCounter = counter._handler as! TestCounter
         let total = Int.random(in: 500 ... 1000)
@@ -43,7 +43,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
-        let name = "counter-\(NSUUID().uuidString)"
+        let name = "counter-\(UUID().uuidString)"
         let value = Int.random(in: Int.min ... Int.max)
         Counter(label: name).increment(by: value)
         let counter = metrics.counters[name] as! TestCounter
@@ -150,7 +150,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         let group = DispatchGroup()
-        let name = "recorder-\(NSUUID().uuidString)"
+        let name = "recorder-\(UUID().uuidString)"
         let recorder = Recorder(label: name)
         let testRecorder = recorder._handler as! TestRecorder
         let total = Int.random(in: 500 ... 1000)
@@ -202,7 +202,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
-        let name = "recorder-\(NSUUID().uuidString)"
+        let name = "recorder-\(UUID().uuidString)"
         let value = Double.random(in: Double(Int.min) ... Double(Int.max))
         Recorder(label: name).record(value)
         let recorder = metrics.recorders[name] as! TestRecorder
@@ -215,7 +215,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         let group = DispatchGroup()
-        let name = "timer-\(NSUUID().uuidString)"
+        let name = "timer-\(UUID().uuidString)"
         let timer = Timer(label: name)
         let testTimer = timer._handler as! TestTimer
         let total = Int.random(in: 500 ... 1000)
@@ -235,7 +235,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
-        let name = "timer-\(NSUUID().uuidString)"
+        let name = "timer-\(UUID().uuidString)"
         let value = Int64.random(in: Int64.min ... Int64.max)
         Timer(label: name).recordNanoseconds(value)
         let timer = metrics.timers[name] as! TestTimer
@@ -339,7 +339,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
-        let name = "gauge-\(NSUUID().uuidString)"
+        let name = "gauge-\(UUID().uuidString)"
         let value = Double.random(in: -1000 ... 1000)
         let gauge = Gauge(label: name)
         gauge.record(value)
@@ -353,7 +353,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
-        let name = "gauge-\(NSUUID().uuidString)"
+        let name = "gauge-\(UUID().uuidString)"
         let value = Double.random(in: -1000 ... 1000)
         Gauge(label: name).record(value)
         let recorder = metrics.recorders[name] as! TestRecorder
@@ -366,7 +366,7 @@ class MetricsTests: XCTestCase {
         let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
         MetricsSystem.bootstrapInternal(MultiplexMetricsHandler(factories: factories))
         // run the test
-        let name = NSUUID().uuidString
+        let name = UUID().uuidString
         let value = Int.random(in: Int.min ... Int.max)
         let muxCounter = Counter(label: name)
         muxCounter.increment(by: value)
@@ -388,7 +388,7 @@ class MetricsTests: XCTestCase {
         let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
         MetricsSystem.bootstrapInternal(MultiplexMetricsHandler(factories: factories))
         // run the test
-        let name = NSUUID().uuidString
+        let name = UUID().uuidString
         let value = Double.random(in: 0 ... 1)
         let muxRecorder = Recorder(label: name)
         muxRecorder.record(value)
@@ -405,7 +405,7 @@ class MetricsTests: XCTestCase {
         let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
         MetricsSystem.bootstrapInternal(MultiplexMetricsHandler(factories: factories))
         // run the test
-        let name = NSUUID().uuidString
+        let name = UUID().uuidString
         let seconds = Int.random(in: 1 ... 10)
         let muxTimer = Timer(label: name, preferredDisplayUnit: .minutes)
         muxTimer.recordSeconds(seconds)
@@ -435,7 +435,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
 
-        let name = "gauge-\(NSUUID().uuidString)"
+        let name = "gauge-\(UUID().uuidString)"
         let value = Double.random(in: -1000 ... 1000)
 
         let gauge = Gauge(label: name)
@@ -465,7 +465,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
 
-        let name = "counter-\(NSUUID().uuidString)"
+        let name = "counter-\(UUID().uuidString)"
         let value = Int.random(in: 0 ... 1000)
 
         let counter = Counter(label: name)
@@ -495,7 +495,7 @@ class MetricsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
 
-        let name = "timer-\(NSUUID().uuidString)"
+        let name = "timer-\(UUID().uuidString)"
         let value = Int64.random(in: 0 ... 1000)
 
         let timer = Timer(label: name)

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -22,7 +22,7 @@ class MetricsExtensionsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
         // run the test
-        let name = "timer-\(NSUUID().uuidString)"
+        let name = "timer-\(UUID().uuidString)"
         let delay = 0.05
         Timer.measure(label: name) {
             Thread.sleep(forTimeInterval: delay)
@@ -99,7 +99,7 @@ class MetricsExtensionsTests: XCTestCase {
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
 
-        let name = "timer-\(NSUUID().uuidString)"
+        let name = "timer-\(UUID().uuidString)"
         let value = Int64.random(in: 0 ... 1000)
 
         let timer = Timer(label: name)
@@ -110,7 +110,7 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testTimer.values.first!.1, value, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
 
-        let secondsName = "timer-seconds-\(NSUUID().uuidString)"
+        let secondsName = "timer-seconds-\(UUID().uuidString)"
         let secondsValue = Int64.random(in: 0 ... 1000)
         let secondsTimer = Timer(label: secondsName, preferredDisplayUnit: .seconds)
         secondsTimer.recordSeconds(secondsValue)

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -81,7 +81,7 @@ internal class TestCounter: CounterHandler, Equatable {
     var values = [(Date, Int64)]()
 
     init(label: String, dimensions: [(String, String)]) {
-        self.id = NSUUID().uuidString
+        self.id = UUID().uuidString
         self.label = label
         self.dimensions = dimensions
     }
@@ -115,7 +115,7 @@ internal class TestRecorder: RecorderHandler, Equatable {
     var values = [(Date, Double)]()
 
     init(label: String, dimensions: [(String, String)], aggregate: Bool) {
-        self.id = NSUUID().uuidString
+        self.id = UUID().uuidString
         self.label = label
         self.dimensions = dimensions
         self.aggregate = aggregate
@@ -148,7 +148,7 @@ internal class TestTimer: TimerHandler, Equatable {
     var values = [(Date, Int64)]()
 
     init(label: String, dimensions: [(String, String)]) {
-        self.id = NSUUID().uuidString
+        self.id = UUID().uuidString
         self.label = label
         self.displayUnit = nil
         self.dimensions = dimensions

--- a/Tests/MetricsTests/TestSendable.swift
+++ b/Tests/MetricsTests/TestSendable.swift
@@ -24,7 +24,7 @@ class SendableTest: XCTestCase {
         MetricsSystem.bootstrapInternal(metrics)
 
         do {
-            let name = "counter-\(NSUUID().uuidString)"
+            let name = "counter-\(UUID().uuidString)"
             let value = Int.random(in: 0 ... 1000)
             let counter = Counter(label: name)
 
@@ -39,7 +39,7 @@ class SendableTest: XCTestCase {
         }
 
         do {
-            let name = "floating-point-counter-\(NSUUID().uuidString)"
+            let name = "floating-point-counter-\(UUID().uuidString)"
             let value = Double.random(in: 0 ... 0.9999)
             let counter = FloatingPointCounter(label: name)
 
@@ -53,7 +53,7 @@ class SendableTest: XCTestCase {
         }
 
         do {
-            let name = "recorder-\(NSUUID().uuidString)"
+            let name = "recorder-\(UUID().uuidString)"
             let value = Double.random(in: -1000 ... 1000)
             let recorder = Recorder(label: name)
 
@@ -68,7 +68,7 @@ class SendableTest: XCTestCase {
         }
 
         do {
-            let name = "gauge-\(NSUUID().uuidString)"
+            let name = "gauge-\(UUID().uuidString)"
             let value = Double.random(in: -1000 ... 1000)
             let gauge = Gauge(label: name)
 
@@ -83,7 +83,7 @@ class SendableTest: XCTestCase {
         }
 
         do {
-            let name = "timer-\(NSUUID().uuidString)"
+            let name = "timer-\(UUID().uuidString)"
             let value = Int64.random(in: 0 ... 1000)
             let timer = Timer(label: name)
 


### PR DESCRIPTION
NSUUID is a reference type. We should stay Swifty and use UUID instead.