### PR TITLE
Introducing Timer.record(_ duration:), closes #114

### DIFF
--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -74,3 +74,16 @@ extension Timer {
         }
     }
 }
+
+extension Timer {
+    /// Convenience for recording a duration based on ``Duration``.
+    ///
+    /// - parameters:
+    ///     - duration: The duration to record.
+    @available(macOS 13, iOS 16, tvOS 15, watchOS 8, *)
+    @inlinable
+    public func record(_ duration: Duration) {
+        let durationSeconds = Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1e18
+        self.recordSeconds(durationSeconds)
+    }
+}

--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -78,16 +78,18 @@ extension Timer {
 #if swift(>=5.7)
 extension Timer {
     /// Convenience for recording a duration based on ``Duration``.
+    /// Duration will be recorded in nanoseconds.
     ///
     /// - parameters:
     ///     - duration: The duration to record.
     @available(macOS 13, iOS 16, tvOS 15, watchOS 8, *)
     @inlinable
     public func record(_ duration: Duration) {
-        // `Duration` doesn't have a nice way to convert it back to `Double` of seconds,
-        // so instead we can multiply attoseconds by 1e18 and add the number of seconds to it.
-        let durationSeconds = Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1e18
-        self.recordSeconds(durationSeconds)
+        // `Duration` doesn't have a nice way to convert it nanoseconds or seconds,
+        // so we'll do the multiplication manually.
+        // nanoseconds are the smallest unit Timer can track, so we'll record in that.
+        let durationNanoseconds = duration.components.seconds * 1_000_000_000 + duration.components.attoseconds / 1_000_000_000
+        self.recordNanoseconds(durationNanoseconds)
     }
 }
 #endif

--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -76,11 +76,6 @@ extension Timer {
 }
 
 #if swift(>=5.7)
-
-public enum TimerError: Error {
-    case durationToIntOverflow
-}
-
 extension Timer {
     /// Convenience for recording a duration based on ``Duration``.
     ///

--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -75,6 +75,7 @@ extension Timer {
     }
 }
 
+#if swift(>=5.7)
 extension Timer {
     /// Convenience for recording a duration based on ``Duration``.
     ///
@@ -83,7 +84,10 @@ extension Timer {
     @available(macOS 13, iOS 16, tvOS 15, watchOS 8, *)
     @inlinable
     public func record(_ duration: Duration) {
+        // `Duration` doesn't have a nice way to convert it back to `Double` of seconds,
+        // so instead we can multiply attoseconds by 1e18 and add the number of seconds to it.
         let durationSeconds = Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1e18
         self.recordSeconds(durationSeconds)
     }
 }
+#endif

--- a/Tests/MetricsTests/MetricsTests+XCTest.swift
+++ b/Tests/MetricsTests/MetricsTests+XCTest.swift
@@ -29,6 +29,7 @@ extension MetricsExtensionsTests {
             ("testTimerWithTimeInterval", testTimerWithTimeInterval),
             ("testTimerWithDispatchTime", testTimerWithDispatchTime),
             ("testTimerWithDispatchTimeInterval", testTimerWithDispatchTimeInterval),
+            ("testTimerDuration", testTimerDuration),
             ("testTimerUnits", testTimerUnits),
             ("testPreferDisplayUnit", testPreferDisplayUnit),
         ]

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -97,6 +97,7 @@ class MetricsExtensionsTests: XCTestCase {
     }
     
     func testTimerDuration() throws {
+#if swift(>=5.7)
         guard #available(iOS 16, macOS 13, tvOS 15, watchOS 8, *) else {
             return
         }
@@ -115,7 +116,9 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testTimer.values.first, durationInNanoseconds, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
+#endif
     }
+
     
 
     func testTimerUnits() throws {

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -108,16 +108,20 @@ class MetricsExtensionsTests: XCTestCase {
         MetricsSystem.bootstrapInternal(metrics)
 
         let name = "timer-\(UUID().uuidString)"
+        let timer = Timer(label: name)
+
         let duration = Duration(secondsComponent: 3, attosecondsComponent: 123_000_000_000_000_000)
         let durationInNanoseconds = duration.components.seconds * 1_000_000_000 + duration.components.attoseconds / 1_000_000_000
 
-        let timer = Timer(label: name)
-        timer.record(duration)
+        XCTAssertNoThrow(try timer.record(duration))
 
         let testTimer = try metrics.expectTimer(timer)
         XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testTimer.values.first, durationInNanoseconds, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
+
+        let overflowDuration = Duration(secondsComponent: 10_000_000_000, attosecondsComponent: 123)
+        XCTAssertThrowsError(try timer.record(overflowDuration))
         #endif
     }
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -101,7 +101,7 @@ class MetricsExtensionsTests: XCTestCase {
         // tests on Linux in MetricsTests+XCTest don't complain that the func does not exist.
         #if swift(>=5.7)
         guard #available(iOS 16, macOS 13, tvOS 15, watchOS 8, *) else {
-            throw XCTSkip("Timer.record(_ duration: Duration) is available on Swift 5.7+")
+            throw XCTSkip("Timer.record(_ duration: Duration) is not available on this platform")
         }
 
         let metrics = TestMetrics()
@@ -123,6 +123,8 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testTimer.values.first, nanoseconds, "expected value to match")
         XCTAssertEqual(testTimer.values[1], Int64.max, "expected to record Int64.max if Durataion overflows")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
+        #else
+            throw XCTSkip("Timer.record(_ duration: Duration) is only available on Swift >=5.7")
         #endif
     }
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -101,7 +101,7 @@ class MetricsExtensionsTests: XCTestCase {
         // tests on Linux in MetricsTests+XCTest don't complain that the func does not exist.
         #if swift(>=5.7)
         guard #available(iOS 16, macOS 13, tvOS 15, watchOS 8, *) else {
-            return
+            throw XCTSkip("Timer.record(_ duration: Duration) is available on Swift 5.7+")
         }
 
         let metrics = TestMetrics()

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -95,6 +95,28 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(UInt64(testTimer.values.first!), end.uptimeNanoseconds - start.uptimeNanoseconds, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
     }
+    
+    func testTimerDuration() throws {
+        guard #available(iOS 16, macOS 13, tvOS 15, watchOS 8, *) else {
+            return
+        }
+        
+        let metrics = TestMetrics()
+        MetricsSystem.bootstrapInternal(metrics)
+        
+        let name = "timer-\(UUID().uuidString)"
+        let duration = Duration(secondsComponent: 3, attosecondsComponent: 123000000000000000)
+        let durationInNanoseconds = duration.components.seconds * 1_000_000_000 + duration.components.attoseconds / 1_000_000_000
+        
+        let timer = Timer(label: name)
+        timer.record(duration)
+        
+        let testTimer = try metrics.expectTimer(timer)
+        XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
+        XCTAssertEqual(testTimer.values.first, durationInNanoseconds, "expected value to match")
+        XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
+    }
+    
 
     func testTimerUnits() throws {
         let metrics = TestMetrics()

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -111,17 +111,18 @@ class MetricsExtensionsTests: XCTestCase {
         let timer = Timer(label: name)
 
         let duration = Duration(secondsComponent: 3, attosecondsComponent: 123_000_000_000_000_000)
-        let durationInNanoseconds = duration.components.seconds * 1_000_000_000 + duration.components.attoseconds / 1_000_000_000
+        let nanoseconds = duration.components.seconds * 1_000_000_000 + duration.components.attoseconds / 1_000_000_000
+        timer.record(duration)
 
-        XCTAssertNoThrow(try timer.record(duration))
+        // Record a Duration that would overflow,
+        // expect Int64.max to be recorded.
+        timer.record(Duration(secondsComponent: 10_000_000_000, attosecondsComponent: 123))
 
         let testTimer = try metrics.expectTimer(timer)
-        XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
-        XCTAssertEqual(testTimer.values.first, durationInNanoseconds, "expected value to match")
+        XCTAssertEqual(testTimer.values.count, 2, "expected number of entries to match")
+        XCTAssertEqual(testTimer.values.first, nanoseconds, "expected value to match")
+        XCTAssertEqual(testTimer.values[1], Int64.max, "expected to record Int64.max if Durataion overflows")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
-
-        let overflowDuration = Duration(secondsComponent: 10_000_000_000, attosecondsComponent: 123)
-        XCTAssertThrowsError(try timer.record(overflowDuration))
         #endif
     }
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -97,6 +97,8 @@ class MetricsExtensionsTests: XCTestCase {
     }
 
     func testTimerDuration() throws {
+        // Wrapping only the insides of the test case so that the generated
+        // tests on Linux in MetricsTests+XCTest don't complain that the func does not exist.
         #if swift(>=5.7)
         guard #available(iOS 16, macOS 13, tvOS 15, watchOS 8, *) else {
             return

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -124,7 +124,7 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testTimer.values[1], Int64.max, "expected to record Int64.max if Durataion overflows")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
         #else
-            throw XCTSkip("Timer.record(_ duration: Duration) is only available on Swift >=5.7")
+        throw XCTSkip("Timer.record(_ duration: Duration) is only available on Swift >=5.7")
         #endif
     }
 

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -123,7 +123,7 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testTimer.values.first, nanoseconds, "expected value to match")
         XCTAssertEqual(testTimer.values[1], Int64.max, "expected to record Int64.max if Durataion overflows")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
-        #else
+        #elseif swift(>=5.2)
         throw XCTSkip("Timer.record(_ duration: Duration) is only available on Swift >=5.7")
         #endif
     }

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -95,31 +95,29 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(UInt64(testTimer.values.first!), end.uptimeNanoseconds - start.uptimeNanoseconds, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
     }
-    
+
     func testTimerDuration() throws {
-#if swift(>=5.7)
+        #if swift(>=5.7)
         guard #available(iOS 16, macOS 13, tvOS 15, watchOS 8, *) else {
             return
         }
-        
+
         let metrics = TestMetrics()
         MetricsSystem.bootstrapInternal(metrics)
-        
+
         let name = "timer-\(UUID().uuidString)"
-        let duration = Duration(secondsComponent: 3, attosecondsComponent: 123000000000000000)
+        let duration = Duration(secondsComponent: 3, attosecondsComponent: 123_000_000_000_000_000)
         let durationInNanoseconds = duration.components.seconds * 1_000_000_000 + duration.components.attoseconds / 1_000_000_000
-        
+
         let timer = Timer(label: name)
         timer.record(duration)
-        
+
         let testTimer = try metrics.expectTimer(timer)
         XCTAssertEqual(testTimer.values.count, 1, "expected number of entries to match")
         XCTAssertEqual(testTimer.values.first, durationInNanoseconds, "expected value to match")
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
-#endif
+        #endif
     }
-
-    
 
     func testTimerUnits() throws {
         let metrics = TestMetrics()

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -64,6 +64,12 @@ fi
 printf "\033[0;32mokay.\033[0m\n"
 
 printf "=> Checking format... "
+
+if [[ ! -x $(which swiftformat) ]]; then
+    printf "\033[0;31mswiftformat not found!\033[0m\n"
+    exit 1
+fi
+
 FIRST_OUT="$(git status --porcelain)"
 swiftformat . > /dev/null 2>&1
 SECOND_OUT="$(git status --porcelain)"


### PR DESCRIPTION
This pull request adds a convenience API to `Timer` that uses Swift 5.7's `Duration`. 

### Motivation:

I'm looking for ways to learn Swift, and it's open source ecosystem by doing, and this looked like a beginner-friendly little addition that @ktoso requested (well, a year ago) in #114.
Closes #114.

### Modifications:

- [x] `Timer.record(_ duration: Duration)` that's available on iOS16 and friends.
- [x] A unit test
- [x] Added the test case to Linux tests
- [x] Soundness check passes.
- [x] Record duration in nanoseconds.

### Where to start the review

- My `@available` check looks weird, I thought `Duration` is available in Swift 5.7, but looks like it's platform-specific. Do they look okay?
- Looks like DocC should pick up the function variant automatically, but I'm happy to add example / other documentation as needed.
- `Duration` conversion to seconds / nanoseconds is lossy and looks a bit janky, but seems like that's how folks are doing it for now?
