### PR TITLE
Check if swiftformat is installed in scripts/soundness.sh

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -27,7 +27,7 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-set -eu
+set -euo pipefail
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
@@ -67,7 +67,7 @@ printf "=> Checking format... "
 
 if [[ ! -x $(which swiftformat) ]]; then
     printf "\033[0;31mswiftformat not found!\033[0m\n"
-    exit 1
+    exit 127
 fi
 
 FIRST_OUT="$(git status --porcelain)"


### PR DESCRIPTION
This pull request adds a check for `swiftformat` executable in `scripts/soundness.sh` so that it doesn't fail silently if the system does not have `swiftformat` installed.

### Motivation:

I was working on #133 and noticed that `soundness` passes locally, but fails on CI. Turned out, it just didn't work locally because I didn't have `swiftformat` installed.

This pull request adds a check that would `exit 1` from soundness if `swiftformat` is not an executable. /cc @ktoso