### PR TITLE
Fix Sendability warnings

### DIFF
--- a/Sources/CoreMetrics/Locks.swift
+++ b/Sources/CoreMetrics/Locks.swift
@@ -46,7 +46,7 @@ import Musl
 /// of lock is safe to use with `libpthread`-based threading models, such as the
 /// one used by NIO. On Windows, the lock is based on the substantially similar
 /// `SRWLOCK` type.
-internal final class Lock: Sendable {
+internal final class Lock {
     #if os(Windows)
     fileprivate let mutex: UnsafeMutablePointer<SRWLOCK> =
         UnsafeMutablePointer.allocate(capacity: 1)
@@ -130,6 +130,8 @@ extension Lock {
         try self.withLock(body)
     }
 }
+
+extension Lock: @unchecked Sendable {}
 
 /// A reader/writer threading lock based on `libpthread` instead of `libdispatch`.
 ///
@@ -273,3 +275,5 @@ extension ReadWriteLock {
         try self.withWriterLock(body)
     }
 }
+
+extension ReadWriteLock: @unchecked Sendable {}

--- a/Sources/CoreMetrics/Locks.swift
+++ b/Sources/CoreMetrics/Locks.swift
@@ -46,7 +46,7 @@ import Musl
 /// of lock is safe to use with `libpthread`-based threading models, such as the
 /// one used by NIO. On Windows, the lock is based on the substantially similar
 /// `SRWLOCK` type.
-internal final class Lock {
+internal final class Lock: Sendable {
     #if os(Windows)
     fileprivate let mutex: UnsafeMutablePointer<SRWLOCK> =
         UnsafeMutablePointer.allocate(capacity: 1)

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -801,7 +801,7 @@ internal final class AccumulatingRoundingFloatingPointCounter: FloatingPointCoun
 internal final class AccumulatingMeter: MeterHandler, @unchecked Sendable {
     private let recorderHandler: RecorderHandler
     // FIXME: use swift-atomics when floating point support is available
-    private var value: Double =  0
+    private var value: Double = 0
     private let lock = Lock()
 
     init(label: String, dimensions: [(String, String)]) {

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -600,7 +600,8 @@ public enum MetricsSystem {
         return try self._factory.withWriterLock(body)
     }
 
-    private final class FactoryBox {
+    // This can be `@unchecked Sendable` because we're manually gating access to mutable state with a lock.
+    private final class FactoryBox: @unchecked Sendable {
         private let lock = ReadWriteLock()
         fileprivate var _underlying: MetricsFactory
         private var initialized = false

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -797,10 +797,11 @@ internal final class AccumulatingRoundingFloatingPointCounter: FloatingPointCoun
 }
 
 /// Wraps a RecorderHandler, adding support for incrementing values by storing an accumulated  value and recording increments to the underlying CounterHandler after crossing integer boundaries.
-internal final class AccumulatingMeter: MeterHandler {
+/// - Note: we can annotate this class as `@unchecked Sendable` because we are manually gating access to mutable state (i.e., the `value` property) via a Lock.
+internal final class AccumulatingMeter: MeterHandler, @unchecked Sendable {
     private let recorderHandler: RecorderHandler
-    // FIXME: use atomics when available
-    private var value: Double = 0
+    // FIXME: use swift-atomics when floating point support is available
+    private var value: Double =  0
     private let lock = Lock()
 
     init(label: String, dimensions: [(String, String)]) {

--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -60,6 +60,16 @@ extension Timer {
     ///     - duration: The duration to record.
     @inlinable
     public func record(_ duration: DispatchTimeInterval) {
+        // This wrapping in a optional is a workaround because DispatchTimeInterval
+        // is a non-frozen public enum and Dispatch is built with library evolution
+        // mode turned on.
+        // This means we should have an `@unknown default` case, but this breaks
+        // on non-Darwin platforms.
+        // Switching over an optional means that the `.none` case will map to
+        // `default` (which means we'll always have a valid case to go into
+        // the default case), but in reality this case will never exist as this
+        // optional will never be nil.
+        let duration = Optional(duration)
         switch duration {
         case .nanoseconds(let value):
             self.recordNanoseconds(value)
@@ -71,7 +81,7 @@ extension Timer {
             self.recordSeconds(value)
         case .never:
             self.record(0)
-        @unknown default:
+        default:
             self.record(0)
         }
     }

--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -71,6 +71,8 @@ extension Timer {
             self.recordSeconds(value)
         case .never:
             self.record(0)
+        @unknown default:
+            self.record(0)
         }
     }
 }

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -185,7 +185,17 @@ class MetricsExtensionsTests: XCTestCase {
 // https://bugs.swift.org/browse/SR-6310
 extension DispatchTimeInterval {
     func nano() -> Int {
-        switch self {
+        // This wrapping in a optional is a workaround because DispatchTimeInterval
+        // is a non-frozen public enum and Dispatch is built with library evolution
+        // mode turned on.
+        // This means we should have an `@unknown default` case, but this breaks
+        // on non-Darwin platforms.
+        // Switching over an optional means that the `.none` case will map to
+        // `default` (which means we'll always have a valid case to go into
+        // the default case), but in reality this case will never exist as this
+        // optional will never be nil.
+        let interval = Optional(self)
+        switch interval {
         case .nanoseconds(let value):
             return value
         case .microseconds(let value):
@@ -196,7 +206,7 @@ extension DispatchTimeInterval {
             return value * 1_000_000_000
         case .never:
             return 0
-        @unknown default:
+        default:
             return 0
         }
     }

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -196,6 +196,8 @@ extension DispatchTimeInterval {
             return value * 1_000_000_000
         case .never:
             return 0
+        @unknown default:
+            return 0
         }
     }
 }


### PR DESCRIPTION
This PR fixes Sendability warnings present when enabling strict concurrency checking.

### Motivation:

We want to make sure `swift-metrics` is free of concurrency bugs, and thus removing Sendability warnings is crucial.

### Modifications:

- Fixed a couple of Sendability warnings that Xcode would report when enabling strict concurrency checking.
- Also fixed other non-Sendability-related warnings about non-exhaustive `switch`es.

### Result:

`swift-metrics` is now warning-free.
