### PR TITLE
Update API breakage CI script

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -176,7 +176,7 @@ extension FloatingPointCounter: CustomStringConvertible {
 /// A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
 /// Gauges are typically used for measured values like temperatures or current memory usage, but also "counts" that can go up and down, like the number of active threads.
 /// Gauges are modeled as `Recorder` with a sample size of 1 and that does not perform any aggregation.
-public final class Gauge: Recorder {
+public final class Gauge: Recorder, @unchecked Sendable {
     /// Create a new `Gauge`.
     ///
     /// - parameters:

--- a/scripts/check_no_api_breakages.sh
+++ b/scripts/check_no_api_breakages.sh
@@ -17,7 +17,7 @@
 ##
 ## This source file is part of the SwiftNIO open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Copyright (c) 2017-2020 Apple Inc. and the SwiftNIO project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -29,44 +29,15 @@
 
 set -eu
 
-# repodir
-function all_modules() {
-    local repodir="$1"
-    (
-    set -eu
-    cd "$repodir"
-    swift package dump-package | jq '.products |
-                                     map(select(.type | has("library") )) |
-                                     map(.name) | .[]' | tr -d '"'
-    )
-}
-
-# repodir tag output
-function build_and_do() {
-    local repodir=$1
-    local tag=$2
-    local output=$3
-
-    (
-    cd "$repodir"
-    git checkout -q "$tag"
-    swift build
-    while read -r module; do
-        swift api-digester -sdk "$sdk" -dump-sdk -module "$module" \
-            -o "$output/$module.json" -I "$repodir/.build/debug"
-    done < <(all_modules "$repodir")
-    )
-}
-
 function usage() {
     echo >&2 "Usage: $0 REPO-GITHUB-URL NEW-VERSION OLD-VERSIONS..."
     echo >&2
-    echo >&2 "This script requires a Swift 5.1+ toolchain."
+    echo >&2 "This script requires a Swift 5.2+ toolchain."
     echo >&2
     echo >&2 "Examples:"
     echo >&2
-    echo >&2 "Check between master and tag 2.1.1 of swift-nio:"
-    echo >&2 "  $0 https://github.com/apple/swift-nio master 2.1.1"
+    echo >&2 "Check between main and tag 2.1.1 of swift-nio:"
+    echo >&2 "  $0 https://github.com/apple/swift-nio main 2.1.1"
     echo >&2
     echo >&2 "Check between HEAD and commit 64cf63d7 using the provided toolchain:"
     echo >&2 "  xcrun --toolchain org.swift.5120190702a $0 ../some-local-repo HEAD 64cf63d7"
@@ -77,12 +48,6 @@ if [[ $# -lt 3 ]]; then
     exit 1
 fi
 
-sdk=/
-if [[ "$(uname -s)" == Darwin ]]; then
-    sdk=$(xcrun --show-sdk-path)
-fi
-
-hash jq 2> /dev/null || { echo >&2 "ERROR: jq must be installed"; exit 1; }
 tmpdir=$(mktemp -d /tmp/.check-api_XXXXXX)
 repo_url=$1
 new_tag=$2
@@ -91,46 +56,13 @@ shift 2
 repodir="$tmpdir/repo"
 git clone "$repo_url" "$repodir"
 git -C "$repodir" fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
-errors=0
+cd "$repodir"
+git checkout -q "$new_tag"
 
 for old_tag in "$@"; do
-    mkdir "$tmpdir/api-old"
-    mkdir "$tmpdir/api-new"
-
     echo "Checking public API breakages from $old_tag to $new_tag"
 
-    build_and_do "$repodir" "$new_tag" "$tmpdir/api-new/"
-    build_and_do "$repodir" "$old_tag" "$tmpdir/api-old/"
-
-    for f in "$tmpdir/api-new"/*; do
-        f=$(basename "$f")
-        report="$tmpdir/$f.report"
-        if [[ ! -f "$tmpdir/api-old/$f" ]]; then
-            echo "NOTICE: NEW MODULE $f"
-            continue
-        fi
-
-        echo -n "Checking $f... "
-        swift api-digester -sdk "$sdk" -diagnose-sdk \
-            --input-paths "$tmpdir/api-old/$f" -input-paths "$tmpdir/api-new/$f" 2>&1 \
-            > "$report" 2>&1
-
-        if ! shasum "$report" | grep -q cefc4ee5bb7bcdb7cb5a7747efa178dab3c794d5; then
-            echo ERROR
-            echo >&2 "=============================="
-            echo >&2 "ERROR: public API change in $f"
-            echo >&2 "=============================="
-            cat >&2 "$report"
-            errors=$(( errors + 1 ))
-        else
-            echo OK
-        fi
-    done
-    rm -rf "$tmpdir/api-new" "$tmpdir/api-old"
+    swift package diagnose-api-breaking-changes "$old_tag"
 done
 
-if [[ "$errors" == 0 ]]; then
-    echo "OK, all seems good"
-fi
 echo done
-exit "$errors"


### PR DESCRIPTION
### Motivation:

The script used in CI to diagnose API breakages is a very old copy of one from NIO. It hand-rolled the builds of the two Git trees and checked the JSON report against a hard-coded SHA. This has been misfiring recently, presumably because the format of the report has changed, even though there are no API breakages.

Here's an example, which fails when comparing `main` with `main` (yes, with itself). It errors and prints the report, which says there aren't any breakages, but the script will then exit non-zero:

```console
% docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.2204.59.yaml -p swift-metrics-api-breakage-prb run --rm shell -cl 'scripts/check_no_api_breakages.sh https://github.com/apple/swift-metrics main main'
...
==============================
ERROR: public API change in Metrics.json
==============================

/* Generic Signature Changes */

/* RawRepresentable Changes */

/* Removed Decls */

/* Moved Decls */

/* Renamed Decls */

/* Type Changes */

/* Decl Attribute changes */

/* Fixed-layout Type Changes */

/* Protocol Conformance Change */

/* Protocol Requirement Change */

/* Class Inheritance Change */

/* Others */
Checking MetricsTestKit.json... ERROR
...
```

These days we have `swift package diagnose-api-breaking-changes` and the script in NIO has been updated to use this for some time.

### Modifications:

Update the CI script to the latest copy of the one used in NIO.

### Result:

Running the script in Docker Compose no longer complains when there are no API breakages.

```console
% docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.2204.59.yaml -p swift-metrics-api-breakage-prb run --rm shell -cl 'scripts/check_no_api_breakages.sh https://github.com/apple/swift-metrics main main'

No breaking changes detected in MetricsTestKit

No breaking changes detected in Metrics

No breaking changes detected in CoreMetrics
```
