### PR TITLE
Change Timer.record(duration: Duration) signature to avoid source breakage

### DIFF
--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -82,11 +82,9 @@ extension Timer {
     ///
     /// - Parameters:
     ///     - duration: The `Duration` to record.
-    ///
-    /// - Throws: `TimerError.durationToIntOverflow` if conversion from `Duration` to `Int64` of Nanoseconds overflowed.
     @available(macOS 13, iOS 16, tvOS 15, watchOS 8, *)
     @inlinable
-    public func record(_ duration: Duration) {
+    public func record(duration: Duration) {
         // `Duration` doesn't have a nice way to convert it nanoseconds or seconds,
         // and manual conversion can overflow.
         let seconds = duration.components.seconds.multipliedReportingOverflow(by: 1_000_000_000)

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -111,11 +111,11 @@ class MetricsExtensionsTests: XCTestCase {
 
         let duration = Duration(secondsComponent: 3, attosecondsComponent: 123_000_000_000_000_000)
         let nanoseconds = duration.components.seconds * 1_000_000_000 + duration.components.attoseconds / 1_000_000_000
-        timer.record(duration)
+        timer.record(duration: duration)
 
         // Record a Duration that would overflow,
         // expect Int64.max to be recorded.
-        timer.record(Duration(secondsComponent: 10_000_000_000, attosecondsComponent: 123))
+        timer.record(duration: Duration(secondsComponent: 10_000_000_000, attosecondsComponent: 123))
 
         let testTimer = try metrics.expectTimer(timer)
         XCTAssertEqual(testTimer.values.count, 2, "expected number of entries to match")


### PR DESCRIPTION
The previous signature introduced in #133 was
```swift
public func record(_ duration: Duration)
```

There was already a similar function
```swift
public func record(_ duration: DispatchTimeInterval)
```

This can cause ambiguity for the compiler when using `.` shortcuts because of an overlap in case names, e.g.
```swift
timer.record(.nanoseconds(123)) // <-- ambiguous, is this DispatchTimeInterval or Duration? 
```

This is a source breaking change, which we have released in 2.4.2
Anyone using code like `timer.record(.nanoseconds(123))`, who has a minimum platform version high enough, will encounter a compiler error on code which compiled fine in 2.4.1 and below

The fix I'm proposing is to add an argument label to the new method to avoid ambiguity, but I'm open to alternative fixes here