### PR TITLE
Add missing `Sendable` annotations

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -374,8 +374,8 @@ extension Recorder: CustomStringConvertible {
 
 // MARK: - Timer
 
-public struct TimeUnit: Equatable {
-    private enum Code: Equatable {
+public struct TimeUnit: Equatable, Sendable {
+    private enum Code: Equatable, Sendable {
         case nanoseconds
         case microseconds
         case milliseconds

--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -43,7 +43,7 @@ public final class TestMetrics: MetricsFactory {
     public typealias Label = String
     public typealias Dimensions = String
 
-    public struct FullKey {
+    public struct FullKey: Sendable {
         let label: Label
         let dimensions: [(String, String)]
     }


### PR DESCRIPTION
# Motivation
We were missing a few `Sendable` annotations on our public types.

# Modification
This PR adds `Sendable` to the missing types.
