### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,3 +46,14 @@ for target in package.targets {
     settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
     target.swiftSettings = settings
 }
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    if target.type != .plugin {
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.