### PR TITLE
If FoundationEssentials is available use it

### DIFF
--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -13,9 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import CoreMetrics
-import Foundation
+import Dispatch
 
 @_exported import class CoreMetrics.Timer
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension Timer {
     /// Convenience for measuring duration of a closure.


### PR DESCRIPTION
Use FoundationEssentials if it is available

### Motivation:

Reduce size of any application using swift-metrics on linux
