### PR TITLE
Android support

### DIFF
--- a/Sources/CoreMetrics/Locks.swift
+++ b/Sources/CoreMetrics/Locks.swift
@@ -34,6 +34,8 @@ import Darwin
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #elseif canImport(Musl)
 import Musl
 #else


### PR DESCRIPTION
This PR makes the single `import Android` addition that is needed to get this package building for Android. `skip android test` passes against the emulator after I made this one change.