### PR TITLE
Sorting dimensions in TestMetrics

### DIFF
--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -148,7 +148,7 @@ public final class TestMetrics: MetricsFactory {
 extension TestMetrics.FullKey: Hashable {
     public func hash(into hasher: inout Hasher) {
         self.label.hash(into: &hasher)
-        for dim in self.dimensions {
+        for dim in self.dimensions.sorted(by: { $0.0 < $1.0 }) {
             dim.0.hash(into: &hasher)
             dim.1.hash(into: &hasher)
         }


### PR DESCRIPTION
### Motivation:

Currently when using the expect Counters,Meters, etc, it thinks there is a missing metric if the dimensions are not in the same order. 

### Modifications:

Sorted dimensions


