### PR TITLE
Update TestMetrics.swift

### DIFF
--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -148,7 +148,7 @@ public final class TestMetrics: MetricsFactory {
 extension TestMetrics.FullKey: Hashable {
     public func hash(into hasher: inout Hasher) {
         self.label.hash(into: &hasher)
-        for dim in self.dimensions {
+        for dim in self.dimensions.sorted(by: { $0.0 < $1.0 }) {
             dim.0.hash(into: &hasher)
             dim.1.hash(into: &hasher)
         }


### PR DESCRIPTION
TestMetrics hashing is unstable due to different possible ordering of the metric dimensions. This change sorts the dimensions to at least reduce the instability, I'm not sure if the dimensions are enforced to be unique given they are of type `[(String, String)]`
