### PR TITLE
TestMetrics.FullKey hash goes via Dictionary

### DIFF
--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -147,11 +147,8 @@ public final class TestMetrics: MetricsFactory {
 
 extension TestMetrics.FullKey: Hashable {
     public func hash(into hasher: inout Hasher) {
-        self.label.hash(into: &hasher)
-        for dim in self.dimensions.sorted(by: { $0.0 < $1.0 }) {
-            dim.0.hash(into: &hasher)
-            dim.1.hash(into: &hasher)
-        }
+        hasher.combine(self.label)
+        hasher.combine(Dictionary(uniqueKeysWithValues: self.dimensions))
     }
 
     public static func == (lhs: TestMetrics.FullKey, rhs: TestMetrics.FullKey) -> Bool {


### PR DESCRIPTION
`TestMetrics.FullKey` `hash` goes via intermediate `Dictionary`.

### Motivation:

Recently a change was made to the `TestMetrics.FullKey.hash` method to make the hashing output stable and remove its dependency on the order of the key-value pairs.

### Modifications:

This PR retains that property but instead of sorting first inserts the key-value pairs into a `Dictionary` as is done in the `==` method.

### Result:

This is useful because it more clearly indicates that the type will comply with the requirement that anything that is equal must produce the same hash.
