### PR TITLE
Add Wasm support and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,13 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+
+  wasm-sdk:
+    name: WebAssembly Swift SDK
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_wasm_sdk_build: true
+      enable_linux_checks: false
+      enable_windows_checks: false
+      swift_flags: --target Metrics
+      swift_nightly_flags: --target Metrics

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,3 +37,13 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+
+  wasm-sdk:
+    name: WebAssembly Swift SDK
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_wasm_sdk_build: true
+      enable_linux_checks: false
+      enable_windows_checks: false
+      swift_flags: --target Metrics
+      swift_nightly_flags: --target Metrics

--- a/Sources/Metrics/Metrics.swift
+++ b/Sources/Metrics/Metrics.swift
@@ -20,6 +20,9 @@ import Foundation
 
 @_exported import class CoreMetrics.Timer
 
+#if canImport(Dispatch)
+import Dispatch
+
 extension Timer {
     /// Convenience for measuring duration of a closure.
     ///
@@ -49,17 +52,6 @@ extension Timer {
     ///   - end: End of the interval, defaulting to `.now()`.
     public func recordInterval(since: DispatchTime, end: DispatchTime = .now()) {
         self.recordNanoseconds(end.uptimeNanoseconds - since.uptimeNanoseconds)
-    }
-}
-
-extension Timer {
-    /// Convenience for recording a duration based on TimeInterval.
-    ///
-    /// - parameters:
-    ///     - duration: The duration to record.
-    @inlinable
-    public func record(_ duration: TimeInterval) {
-        self.recordSeconds(duration)
     }
 
     /// Convenience for recording a duration based on DispatchTimeInterval.
@@ -92,6 +84,18 @@ extension Timer {
         default:
             self.record(0)
         }
+    }
+}
+#endif
+
+extension Timer {
+    /// Convenience for recording a duration based on TimeInterval.
+    ///
+    /// - parameters:
+    ///     - duration: The duration to record.
+    @inlinable
+    public func record(_ duration: TimeInterval) {
+        self.recordSeconds(duration)
     }
 }
 

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -17,7 +17,13 @@ import XCTest
 
 @testable import CoreMetrics
 
+#if canImport(Dispatch)
+import Dispatch
+#endif
+
 class MetricsTests: XCTestCase {
+
+    #if canImport(Dispatch)
     func testCounters() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
@@ -39,6 +45,7 @@ class MetricsTests: XCTestCase {
         testCounter.reset()
         XCTAssertEqual(testCounter.values.count, 0, "expected number of entries to match")
     }
+    #endif
 
     func testCounterBlock() throws {
         // bootstrap with our test metrics
@@ -147,6 +154,7 @@ class MetricsTests: XCTestCase {
         XCTAssertEqual(rawFpCounter.fraction, 0.010009765625, "expected fractional accumulated value")
     }
 
+    #if canImport(Dispatch)
     func testRecorders() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
@@ -166,6 +174,7 @@ class MetricsTests: XCTestCase {
         group.wait()
         XCTAssertEqual(testRecorder.values.count, total, "expected number of entries to match")
     }
+    #endif
 
     func testRecordersInt() throws {
         // bootstrap with our test metrics
@@ -212,6 +221,7 @@ class MetricsTests: XCTestCase {
         XCTAssertEqual(recorder.lastValue, value, "expected value to match")
     }
 
+    #if canImport(Dispatch)
     func testTimers() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
@@ -231,6 +241,7 @@ class MetricsTests: XCTestCase {
         group.wait()
         XCTAssertEqual(testTimer.values.count, total, "expected number of entries to match")
     }
+    #endif
 
     func testTimerBlock() throws {
         // bootstrap with our test metrics
@@ -422,6 +433,7 @@ class MetricsTests: XCTestCase {
         }
     }
 
+    #if canImport(Dispatch)
     func testMeterIncrement() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
@@ -466,6 +478,7 @@ class MetricsTests: XCTestCase {
         XCTAssertEqual(testMeter.values.count, values.count, "expected number of entries to match")
         XCTAssertEqual(testMeter.values.last!, values.reduce(0.0, -), accuracy: 0.1, "expected total value to match")
     }
+    #endif
 
     func testDefaultMeterIgnoresNan() throws {
         // bootstrap with our test metrics

--- a/Tests/MetricsTests/MetricsTests.swift
+++ b/Tests/MetricsTests/MetricsTests.swift
@@ -12,13 +12,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import MetricsTestKit
 import XCTest
 
 @testable import CoreMetrics
 @testable import Metrics
 
+#if canImport(Dispatch)
+import Dispatch
+#endif
+
 class MetricsExtensionsTests: XCTestCase {
+
+    #if canImport(Dispatch)
     func testTimerBlock() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
@@ -33,6 +40,7 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(1, timer.values.count, "expected number of entries to match")
         XCTAssertGreaterThan(timer.values[0], Int64(delay * 1_000_000_000), "expected delay to match")
     }
+    #endif
 
     func testTimerWithTimeInterval() throws {
         // bootstrap with our test metrics
@@ -47,6 +55,7 @@ class MetricsExtensionsTests: XCTestCase {
         XCTAssertEqual(testTimer.values[0], Int64(timeInterval * 1_000_000_000), "expected value to match")
     }
 
+    #if canImport(Dispatch)
     func testTimerWithDispatchTime() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
@@ -100,6 +109,7 @@ class MetricsExtensionsTests: XCTestCase {
         )
         XCTAssertEqual(metrics.timers.count, 1, "timer should have been stored")
     }
+    #endif
 
     func testTimerDuration() throws {
         // Wrapping only the insides of the test case so that the generated
@@ -259,6 +269,7 @@ class MetricsExtensionsTests: XCTestCase {
     #endif
 }
 
+#if canImport(Dispatch)
 // https://bugs.swift.org/browse/SR-6310
 extension DispatchTimeInterval {
     func nano() -> Int {
@@ -288,6 +299,7 @@ extension DispatchTimeInterval {
         }
     }
 }
+#endif
 
 #if swift(>=5.7)
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)

--- a/Tests/MetricsTests/TestSendable.swift
+++ b/Tests/MetricsTests/TestSendable.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
 import MetricsTestKit
 import XCTest
 


### PR DESCRIPTION
### Motivation:

As part of expanding platform and CI coverage of Swift Configuration, Swift Metrics should also build on Wasm.

### Modifications:

- Brought over locking changes from Swift Log to support Wasm.
- Hid some APIs that require Dispatch when Dispatch isn't available.

### Result:

The package now builds against the Wasm SDK, both normal and the test targets.
