### PR TITLE
Mapping metrics factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ before forwarding it to the upstream factory:
 
 ```swift
 // Add a "service" dimension to all metrics created through this factory
-let factory = myMetricsImplementation.mappingLabelsAndDimensions { label, dimensions in
+let factory = myMetricsImplementation.withLabelAndDimensionsMapping { label, dimensions in
     (label, dimensions + [("service", "checkout")])
 }
 let counter = Counter(label: "request_count", dimensions: [("method", "GET")], factory: factory)
@@ -143,10 +143,10 @@ Transforms can also be chained:
 
 ```swift
 let factory = myMetricsImplementation
-    .mappingLabelsAndDimensions { label, dimensions in
+    .withLabelAndDimensionsMapping { label, dimensions in
         ("myapp.\(label)", dimensions)
     }
-    .mappingLabelsAndDimensions { label, dimensions in
+    .withLabelAndDimensionsMapping { label, dimensions in
         (label, dimensions + [("env", "production")])
     }
 ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,33 @@ recorder.record(100)
 timer.recordMilliseconds(100)
 ```
 
+### Transforming labels and dimensions
+
+When integrating metrics from multiple libraries or subsystems, you may want to add common dimensions
+(such as service name or environment) or rename labels consistently. `MappingMetricsFactory` wraps an
+existing `MetricsFactory` and applies a transformation to the label and dimensions of every metric
+before forwarding it to the upstream factory:
+
+```swift
+// Add a "service" dimension to all metrics created through this factory
+let factory = myMetricsImplementation.mappingLabelsAndDimensions { label, dimensions in
+    (label, dimensions + [("service", "checkout")])
+}
+let counter = Counter(label: "request_count", dimensions: [("method", "GET")], factory: factory)
+```
+
+Transforms can also be chained:
+
+```swift
+let factory = myMetricsImplementation
+    .mappingLabelsAndDimensions { label, dimensions in
+        ("myapp.\(label)", dimensions)
+    }
+    .mappingLabelsAndDimensions { label, dimensions in
+        (label, dimensions + [("env", "production")])
+    }
+```
+
 ### Implementing a metrics backend (e.g. Prometheus client library)
 
 Note: Unless you need to implement a custom metrics backend, everything in this section is likely not relevant, so please feel free to skip.

--- a/Sources/CoreMetrics/Docs.docc/Proposals/SMT-0002-mapping-metrics-factory.md
+++ b/Sources/CoreMetrics/Docs.docc/Proposals/SMT-0002-mapping-metrics-factory.md
@@ -51,7 +51,7 @@ Prometheus uses underscores, while others may use dots or other separators. With
 generic transform, each library would need to implement its own renaming support, duplicating the same logic across the
 ecosystem. A factory-level transform keeps renaming generic and reusable by any library.
 
-A core role of swift-metrics is to make it easy to connect libraries with metrics backends. Providing a standard
+A core role of `swift-metrics` is to make it easy to connect libraries with metrics backends. Providing a standard
 mapping factory in the library ensures that every library and backend in the ecosystem shares a single, well-tested
 implementation instead of each project rolling its own wrapper with subtly different semantics.
 

--- a/Sources/CoreMetrics/Docs.docc/Proposals/SMT-0002-mapping-metrics-factory.md
+++ b/Sources/CoreMetrics/Docs.docc/Proposals/SMT-0002-mapping-metrics-factory.md
@@ -1,0 +1,225 @@
+# SMT-0002: mapping metrics factory
+
+A `MetricsFactory` wrapper that transforms labels and dimensions before forwarding to an upstream factory.
+
+## Overview
+
+- Proposal: SMT-0002
+- Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
+- Status: **Awaiting Review**
+- Implementation:
+  - [apple/swift-metrics#194](https://github.com/apple/swift-metrics/pull/194)
+- Related links:
+  - [Lightweight proposals process description](https://github.com/apple/swift-metrics/blob/main/Sources/CoreMetrics/Docs.docc/Proposals/Proposals.md)
+
+### Introduction
+
+Add `MappingMetricsFactory`, a wrapper that applies a user-supplied transformation to the label and dimensions of
+every metric before forwarding creation to an upstream `MetricsFactory`.
+
+### Motivation
+
+Libraries that emit metrics today have no built-in way to let the application customize metric labels or dimensions at
+the factory level. This forces several common patterns into ad-hoc, error-prone workarounds:
+
+**Adding common dimensions across all metrics.**
+In multi-service or multi-region deployments, every metric should carry dimensions such as `service`, `env`, or
+`region`. Without a factory-level transform, each call site must remember to include them:
+
+```swift
+// Every call site must repeat the same dimensions — easy to forget one.
+let counter = Counter(
+    label: "http_requests_total",
+    dimensions: [("method", "GET"), ("service", "checkout"), ("env", "production")]
+)
+let timer = Timer(
+    label: "http_request_duration",
+    dimensions: [("method", "GET"), ("service", "checkout"), ("env", "production")]
+)
+```
+
+**Namespacing third-party library metrics.**
+When integrating a library that defines its own metric labels (for example, `db.query.duration`), the application may
+want to prefix them (`myapp.db.query.duration`) to avoid collisions or improve discoverability. Today, this requires
+either
+patching the library or writing a custom `MetricsFactory` implementation that only adds a prefix.
+
+**Adapting shared library metrics to different backend naming conventions.**
+Libraries like [swift-system-metrics](https://github.com/apple/swift-system-metrics) emit a fixed set of metric labels
+(for example, `process_cpu_usage`, `process_memory_virtual`). Different backends expect different naming conventions:
+Prometheus uses underscores, while others may use dots or other separators. Without a
+generic transform, each library would need to implement its own renaming support, duplicating the same logic across the
+ecosystem. A factory-level transform keeps renaming generic and reusable by any library.
+
+A core role of swift-metrics is to make it easy to connect libraries with metrics backends. Providing a standard
+mapping factory in the library ensures that every library and backend in the ecosystem shares a single, well-tested
+implementation instead of each project rolling its own wrapper with subtly different semantics.
+
+### Proposed solution
+
+Introduce a new public type `MappingMetricsFactory` and a convenience method on `MetricsFactory`:
+
+```swift
+let factory = metricsBackend.withLabelAndDimensionsMapping { label, dimensions in
+    ("myapp.\(label)", dimensions + [("env", "production")])
+}
+
+// All metrics created through this factory get the prefix and dimension automatically.
+let counter = Counter(label: "http_requests", dimensions: [("method", "GET")], factory: factory)
+// The upstream backend receives label "myapp.http_requests"
+// with dimensions [("method", "GET"), ("env", "production")].
+```
+
+### Detailed design
+
+**New type: `MappingMetricsFactory`.**
+
+```swift
+/// A metrics factory that transforms labels and dimensions before forwarding to an upstream factory.
+///
+/// `MappingMetricsFactory` wraps an existing ``MetricsFactory`` and applies a transformation to the label
+/// and dimensions of every metric before creating it in the upstream factory. This is useful for adding
+/// common dimensions (for example, service name, environment), renaming labels, or filtering dimensions
+/// across all metrics created through this factory.
+///
+/// The transformation is applied once at metric creation time (inside each `make*` call), not on every
+/// `increment`, `record`, or other recording operation. This keeps the hot path free of user-supplied
+/// code.
+///
+/// ### Label divergence
+///
+/// The transformation only affects what the upstream factory receives. The metric object itself (for
+/// example, `Counter.label`, `Counter.dimensions`) retains the original values passed at creation time.
+/// This means the label you see on the metric handle may differ from the label stored in the backend:
+///
+/// ```swift
+/// let factory = upstream.withLabelAndDimensionsMapping { label, dimensions in
+///     ("myapp.\(label)", dimensions)
+/// }
+/// let counter = Counter(label: "requests", factory: factory)
+/// // counter.label == "requests"                  — original value on the handle
+/// // backend received label == "myapp.requests"   — transformed value in the backend
+/// ```
+///
+/// Keeping the original label on the metric object helps when debugging local code. This discrepancy
+/// only requires attention when correlating local metric handles with data in a remote backend.
+public struct MappingMetricsFactory<Upstream: MetricsFactory>: Sendable {
+    /// Create a new `MappingMetricsFactory`.
+    ///
+    /// - parameters:
+    ///   - upstream: The upstream ``MetricsFactory`` to forward metric creation to after transformation.
+    ///   - transform: A closure that maps the label and dimensions to new values before forwarding
+    ///     to the upstream factory.
+    public init(
+        upstream: Upstream,
+        transform: @escaping @Sendable (String, [(String, String)]) -> (String, [(String, String)])
+    )
+}
+
+extension MappingMetricsFactory: MetricsFactory {
+    /// Create a backing counter handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `CounterHandler`.
+    ///   - dimensions: The dimensions for the `CounterHandler`.
+    public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler
+
+    /// Create a backing floating-point counter handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `FloatingPointCounterHandler`.
+    ///   - dimensions: The dimensions for the `FloatingPointCounterHandler`.
+    public func makeFloatingPointCounter(label: String, dimensions: [(String, String)]) -> FloatingPointCounterHandler
+
+    /// Create a backing meter handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `MeterHandler`.
+    ///   - dimensions: The dimensions for the `MeterHandler`.
+    public func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler
+
+    /// Create a backing recorder handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `RecorderHandler`.
+    ///   - dimensions: The dimensions for the `RecorderHandler`.
+    ///   - aggregate: A Boolean value that indicates whether to aggregate values.
+    public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler
+
+    /// Create a backing timer handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `TimerHandler`.
+    ///   - dimensions: The dimensions for the `TimerHandler`.
+    public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler
+
+    /// Invoked when the corresponding counter's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
+    public func destroyCounter(_ handler: CounterHandler)
+
+    /// Invoked when the corresponding floating-point counter's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
+    public func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler)
+
+    /// Invoked when the corresponding meter's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
+    public func destroyMeter(_ handler: MeterHandler)
+
+    /// Invoked when the corresponding recorder's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
+    public func destroyRecorder(_ handler: RecorderHandler)
+
+    /// Invoked when the corresponding timer's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
+    public func destroyTimer(_ handler: TimerHandler)
+}
+```
+
+**New extension method on `MetricsFactory`.**
+
+```swift
+extension MetricsFactory {
+    /// Create a new ``MappingMetricsFactory`` that applies the given transformation to all metrics
+    /// created through it.
+    ///
+    /// - parameters:
+    ///   - transform: A closure that maps the label and dimensions to new values.
+    /// - returns: A ``MappingMetricsFactory`` wrapping this factory with the given transformation.
+    public func withLabelAndDimensionsMapping(
+        _ transform: @escaping @Sendable (String, [(String, String)]) -> (String, [(String, String)])
+    ) -> MappingMetricsFactory<Self>
+}
+```
+
+### API stability
+
+**Existing `MetricsFactory` implementations** are not affected. `MappingMetricsFactory` is a new type that wraps
+existing factories; it does not change the `MetricsFactory` protocol.
+
+**Existing users of Metrics** might be affected. The new extension method on `MetricsFactory` is additive. However,
+there is a risk users might already have a `withLabelAndDimensionsMapping` method in a custom extension.
+
+### Future directions
+
+**Exposing the post-transform identity from a metric handle.**
+Today, `Counter.label` and `Counter.dimensions` return the original (pre-transform) values. While it makes sense as
+metric objects carry exactly the label given when constructing them, a future API could let
+callers retrieve the transformed identity that the backend actually received, improving debuggability and mapping
+metric objects to the remote reporting.
+
+### Alternatives considered
+
+**Separate methods for label-only and dimension-only transforms.**
+Two methods like `mappingLabel(_:)` and `mappingDimensions(_:)` would be more targeted but less flexible — some
+transforms might need to modify both the label and dimensions together (for example, extracting part of the label
+into a dimension). A single transform that receives both avoids the need for two factory wrappers.

--- a/Sources/CoreMetrics/Docs.docc/Proposals/SMT-0002-mapping-metrics-factory.md
+++ b/Sources/CoreMetrics/Docs.docc/Proposals/SMT-0002-mapping-metrics-factory.md
@@ -6,7 +6,7 @@ A `MetricsFactory` wrapper that transforms labels and dimensions before forwardi
 
 - Proposal: SMT-0002
 - Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
-- Status: **Awaiting Review**
+- Status: **Approved**
 - Implementation:
   - [apple/swift-metrics#194](https://github.com/apple/swift-metrics/pull/194)
 - Related links:

--- a/Sources/CoreMetrics/Docs.docc/index.md
+++ b/Sources/CoreMetrics/Docs.docc/index.md
@@ -93,7 +93,7 @@ and dimensions of every metric before forwarding it to the upstream factory:
 
 ```swift
 // Add a "service" dimension to all metrics created through this factory
-let factory = myMetricsImplementation.mappingLabelsAndDimensions { label, dimensions in
+let factory = myMetricsImplementation.withLabelAndDimensionsMapping { label, dimensions in
     (label, dimensions + [("service", "checkout")])
 }
 let counter = Counter(label: "request_count", dimensions: [("method", "GET")], factory: factory)
@@ -103,10 +103,10 @@ Transforms can also be chained:
 
 ```swift
 let factory = myMetricsImplementation
-    .mappingLabelsAndDimensions { label, dimensions in
+    .withLabelAndDimensionsMapping { label, dimensions in
         ("myapp.\(label)", dimensions)
     }
-    .mappingLabelsAndDimensions { label, dimensions in
+    .withLabelAndDimensionsMapping { label, dimensions in
         (label, dimensions + [("env", "production")])
     }
 ```

--- a/Sources/CoreMetrics/Docs.docc/index.md
+++ b/Sources/CoreMetrics/Docs.docc/index.md
@@ -84,6 +84,33 @@ This API was designed with the contributors to the Swift on Server community and
 [discussion](https://forums.swift.org/t/discussion-server-metrics-api/) |
 [feedback](https://forums.swift.org/t/feedback-server-metrics-api/)
 
+### Transforming labels and dimensions
+
+When integrating metrics from multiple libraries or subsystems, you may want to add common dimensions
+(such as service name or environment) or rename labels consistently.
+``MappingMetricsFactory`` wraps an existing ``MetricsFactory`` and applies a transformation to the label
+and dimensions of every metric before forwarding it to the upstream factory:
+
+```swift
+// Add a "service" dimension to all metrics created through this factory
+let factory = myMetricsImplementation.mappingLabelsAndDimensions { label, dimensions in
+    (label, dimensions + [("service", "checkout")])
+}
+let counter = Counter(label: "request_count", dimensions: [("method", "GET")], factory: factory)
+```
+
+Transforms can also be chained:
+
+```swift
+let factory = myMetricsImplementation
+    .mappingLabelsAndDimensions { label, dimensions in
+        ("myapp.\(label)", dimensions)
+    }
+    .mappingLabelsAndDimensions { label, dimensions in
+        (label, dimensions + [("env", "production")])
+    }
+```
+
 ## Related Libraries
 
 [swift-system-metrics](https://github.com/apple/swift-system-metrics) uses the Metrics API to emit system resource metrics such as CPU, memory, and file descriptors, providing insight into your application's resource consumption.
@@ -109,10 +136,11 @@ This API was designed with the contributors to the Swift on Server community and
 - ``MultiplexMetricsHandler``
 - ``NOOPMetricsHandler``
 
-### Bootstraping
+### Bootstrapping
 
 - ``MetricsFactory``
 - ``MetricsSystem``
+- ``MappingMetricsFactory``
 
 ### Supporting Types
 

--- a/Sources/CoreMetrics/MappingMetricsFactory.swift
+++ b/Sources/CoreMetrics/MappingMetricsFactory.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Metrics API open source project
+//
+// Copyright (c) 2018-2026 Apple Inc. and the Swift Metrics API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public struct MappingMetricsFactory<Upstream: MetricsFactory>: Sendable {
+    private let upstream: Upstream
+    private let transform: @Sendable (String, [(String, String)]) -> (String, [(String, String)])
+
+    public init(upstream: Upstream, transform: @escaping @Sendable (String, [(String, String)]) -> (String, [(String, String)])) {
+        self.upstream = upstream
+        self.transform = transform
+    }
+}
+
+extension MetricsFactory {
+    public func mappingLabelsAndDimensions(
+        _ transform: @escaping @Sendable (String, [(String, String)]
+    ) -> (String, [(String, String)])) -> MappingMetricsFactory<Self> {
+        MappingMetricsFactory(upstream: self, transform: transform)
+    }
+}
+
+extension MappingMetricsFactory: MetricsFactory {
+    public func makeCounter(
+        label: String,
+        dimensions: [(String, String)]
+    ) -> any CounterHandler {
+        let (newLabel, newDimensions) = transform(label, dimensions)
+        return upstream.makeCounter(label: newLabel, dimensions: newDimensions)
+    }
+
+    public func makeFloatingPointCounter(
+        label: String,
+        dimensions: [(String, String)]
+    ) -> FloatingPointCounterHandler {
+        let (newLabel, newDimensions) = transform(label, dimensions)
+        return upstream.makeFloatingPointCounter(label: newLabel, dimensions: newDimensions)
+    }
+
+    public func makeMeter(
+        label: String,
+        dimensions: [(String, String)]
+    ) -> MeterHandler {
+        let (newLabel, newDimensions) = transform(label, dimensions)
+        return upstream.makeMeter(label: newLabel, dimensions: newDimensions)
+    }
+
+    public func makeRecorder(
+        label: String,
+        dimensions: [(String, String)],
+        aggregate: Bool
+    ) -> any RecorderHandler {
+        let (newLabel, newDimensions) = transform(label, dimensions)
+        return upstream.makeRecorder(label: newLabel, dimensions: newDimensions, aggregate: aggregate)
+    }
+
+    public func makeTimer(
+        label: String,
+        dimensions: [(String, String)]
+    ) -> any TimerHandler {
+        let (newLabel, newDimensions) = transform(label, dimensions)
+        return upstream.makeTimer(label: newLabel, dimensions: newDimensions)
+    }
+
+    public func destroyCounter(_ handler: any CounterHandler) {
+        upstream.destroyCounter(handler)
+    }
+
+    public func destroyMeter(_ handler: MeterHandler) {
+        upstream.destroyMeter(handler)
+    }
+
+    public func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler) {
+        upstream.destroyFloatingPointCounter(handler)
+    }
+
+    public func destroyRecorder(_ handler: any RecorderHandler) {
+        upstream.destroyRecorder(handler)
+    }
+
+    public func destroyTimer(_ handler: any TimerHandler) {
+        upstream.destroyTimer(handler)
+    }
+}

--- a/Sources/CoreMetrics/MappingMetricsFactory.swift
+++ b/Sources/CoreMetrics/MappingMetricsFactory.swift
@@ -16,8 +16,8 @@
 ///
 /// `MappingMetricsFactory` wraps an existing ``MetricsFactory`` and applies a transformation to the label
 /// and dimensions of every metric before creating it in the upstream factory. This is useful for adding
-/// common dimensions (e.g. service name, environment), renaming labels, or filtering dimensions across
-/// all metrics created through this factory.
+/// common dimensions (for example, service name, environment), renaming labels, or filtering dimensions
+/// across all metrics created through this factory.
 ///
 /// ```swift
 /// let factory = upstream.withLabelAndDimensionsMapping { label, dimensions in
@@ -29,10 +29,11 @@
 /// ```
 ///
 /// - Note: The transformation only affects what the upstream factory receives. The metric object itself
-///   (e.g. `Counter.label`, `Counter.dimensions`) retains the original values passed at creation time.
-///   This means the label you see on the metric handle may differ from the label stored in the backend.
-///   When debugging, inspect the metric directly in the backend rather than relying on the metric
-///   handle's `.label` property.
+///   (for example, `Counter.label`, `Counter.dimensions`) retains the original values passed at creation
+///   time. This means the label you see on the metric handle may differ from the label stored in the
+///   backend. Keeping the original label on the metric object helps when debugging local code. This
+///   discrepancy only requires attention when correlating local metric handles with data in a remote
+///   backend.
 public struct MappingMetricsFactory<Upstream: MetricsFactory>: Sendable {
     private let upstream: Upstream
     private let transform: @Sendable (String, [(String, String)]) -> (String, [(String, String)])

--- a/Sources/CoreMetrics/MappingMetricsFactory.swift
+++ b/Sources/CoreMetrics/MappingMetricsFactory.swift
@@ -12,33 +12,80 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A metrics factory that transforms labels and dimensions before forwarding to an upstream factory.
+///
+/// `MappingMetricsFactory` wraps an existing ``MetricsFactory`` and applies a transformation to the label
+/// and dimensions of every metric before creating it in the upstream factory. This is useful for adding
+/// common dimensions (e.g. service name, environment), renaming labels, or filtering dimensions across
+/// all metrics created through this factory.
+///
+/// ```swift
+/// let factory = upstream.mappingLabelsAndDimensions { label, dimensions in
+///     (label, dimensions + [("service", "my-service")])
+/// }
+/// let counter = Counter(label: "request_count", dimensions: [("method", "GET")], factory: factory)
+/// counter.increment()
+/// // The upstream factory sees dimensions [("method", "GET"), ("service", "my-service")]
+/// ```
+///
+/// - Note: The transformation only affects what the upstream factory receives. The metric object itself
+///   (e.g. `Counter.label`, `Counter.dimensions`) retains the original values passed at creation time.
+///   This means the label you see on the metric handle may differ from the label stored in the backend.
 public struct MappingMetricsFactory<Upstream: MetricsFactory>: Sendable {
     private let upstream: Upstream
     private let transform: @Sendable (String, [(String, String)]) -> (String, [(String, String)])
 
-    public init(upstream: Upstream, transform: @escaping @Sendable (String, [(String, String)]) -> (String, [(String, String)])) {
+    /// Create a new `MappingMetricsFactory`.
+    ///
+    /// - parameters:
+    ///   - upstream: The upstream ``MetricsFactory`` to forward metric creation to after transformation.
+    ///   - transform: A closure that maps the label and dimensions to new values before forwarding
+    ///     to the upstream factory.
+    public init(
+        upstream: Upstream,
+        transform: @escaping @Sendable (String, [(String, String)]) -> (String, [(String, String)])
+    ) {
         self.upstream = upstream
         self.transform = transform
     }
 }
 
 extension MetricsFactory {
+    /// Create a new ``MappingMetricsFactory`` that applies the given transformation to all metrics
+    /// created through it.
+    ///
+    /// - parameters:
+    ///   - transform: A closure that maps the label and dimensions to new values.
+    /// - returns: A ``MappingMetricsFactory`` wrapping this factory with the given transformation.
     public func mappingLabelsAndDimensions(
-        _ transform: @escaping @Sendable (String, [(String, String)]
-    ) -> (String, [(String, String)])) -> MappingMetricsFactory<Self> {
+        _ transform:
+            @escaping @Sendable (
+                String, [(String, String)]
+            ) -> (String, [(String, String)])
+    ) -> MappingMetricsFactory<Self> {
         MappingMetricsFactory(upstream: self, transform: transform)
     }
 }
 
 extension MappingMetricsFactory: MetricsFactory {
+    /// Create a backing counter handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `CounterHandler`.
+    ///   - dimensions: The dimensions for the `CounterHandler`.
     public func makeCounter(
         label: String,
         dimensions: [(String, String)]
-    ) -> any CounterHandler {
+    ) -> CounterHandler {
         let (newLabel, newDimensions) = transform(label, dimensions)
         return upstream.makeCounter(label: newLabel, dimensions: newDimensions)
     }
 
+    /// Create a backing floating-point counter handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `FloatingPointCounterHandler`.
+    ///   - dimensions: The dimensions for the `FloatingPointCounterHandler`.
     public func makeFloatingPointCounter(
         label: String,
         dimensions: [(String, String)]
@@ -47,6 +94,11 @@ extension MappingMetricsFactory: MetricsFactory {
         return upstream.makeFloatingPointCounter(label: newLabel, dimensions: newDimensions)
     }
 
+    /// Create a backing meter handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `MeterHandler`.
+    ///   - dimensions: The dimensions for the `MeterHandler`.
     public func makeMeter(
         label: String,
         dimensions: [(String, String)]
@@ -55,40 +107,71 @@ extension MappingMetricsFactory: MetricsFactory {
         return upstream.makeMeter(label: newLabel, dimensions: newDimensions)
     }
 
+    /// Create a backing recorder handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `RecorderHandler`.
+    ///   - dimensions: The dimensions for the `RecorderHandler`.
+    ///   - aggregate: A Boolean value that indicates whether to aggregate values.
     public func makeRecorder(
         label: String,
         dimensions: [(String, String)],
         aggregate: Bool
-    ) -> any RecorderHandler {
+    ) -> RecorderHandler {
         let (newLabel, newDimensions) = transform(label, dimensions)
         return upstream.makeRecorder(label: newLabel, dimensions: newDimensions, aggregate: aggregate)
     }
 
+    /// Create a backing timer handler with transformed label and dimensions.
+    ///
+    /// - parameters:
+    ///   - label: The label for the `TimerHandler`.
+    ///   - dimensions: The dimensions for the `TimerHandler`.
     public func makeTimer(
         label: String,
         dimensions: [(String, String)]
-    ) -> any TimerHandler {
+    ) -> TimerHandler {
         let (newLabel, newDimensions) = transform(label, dimensions)
         return upstream.makeTimer(label: newLabel, dimensions: newDimensions)
     }
 
-    public func destroyCounter(_ handler: any CounterHandler) {
+    /// Invoked when the corresponding counter's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
+    public func destroyCounter(_ handler: CounterHandler) {
         upstream.destroyCounter(handler)
     }
 
+    /// Invoked when the corresponding meter's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
     public func destroyMeter(_ handler: MeterHandler) {
         upstream.destroyMeter(handler)
     }
 
+    /// Invoked when the corresponding floating-point counter's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
     public func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler) {
         upstream.destroyFloatingPointCounter(handler)
     }
 
-    public func destroyRecorder(_ handler: any RecorderHandler) {
+    /// Invoked when the corresponding recorder's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
+    public func destroyRecorder(_ handler: RecorderHandler) {
         upstream.destroyRecorder(handler)
     }
 
-    public func destroyTimer(_ handler: any TimerHandler) {
+    /// Invoked when the corresponding timer's `destroy()` function is invoked.
+    ///
+    /// - parameters:
+    ///   - handler: The handler to be destroyed.
+    public func destroyTimer(_ handler: TimerHandler) {
         upstream.destroyTimer(handler)
     }
 }

--- a/Sources/CoreMetrics/MappingMetricsFactory.swift
+++ b/Sources/CoreMetrics/MappingMetricsFactory.swift
@@ -20,7 +20,7 @@
 /// all metrics created through this factory.
 ///
 /// ```swift
-/// let factory = upstream.mappingLabelsAndDimensions { label, dimensions in
+/// let factory = upstream.withLabelAndDimensionsMapping { label, dimensions in
 ///     (label, dimensions + [("service", "my-service")])
 /// }
 /// let counter = Counter(label: "request_count", dimensions: [("method", "GET")], factory: factory)
@@ -31,6 +31,8 @@
 /// - Note: The transformation only affects what the upstream factory receives. The metric object itself
 ///   (e.g. `Counter.label`, `Counter.dimensions`) retains the original values passed at creation time.
 ///   This means the label you see on the metric handle may differ from the label stored in the backend.
+///   When debugging, inspect the metric directly in the backend rather than relying on the metric
+///   handle's `.label` property.
 public struct MappingMetricsFactory<Upstream: MetricsFactory>: Sendable {
     private let upstream: Upstream
     private let transform: @Sendable (String, [(String, String)]) -> (String, [(String, String)])
@@ -57,7 +59,7 @@ extension MetricsFactory {
     /// - parameters:
     ///   - transform: A closure that maps the label and dimensions to new values.
     /// - returns: A ``MappingMetricsFactory`` wrapping this factory with the given transformation.
-    public func mappingLabelsAndDimensions(
+    public func withLabelAndDimensionsMapping(
         _ transform:
             @escaping @Sendable (
                 String, [(String, String)]

--- a/Sources/CoreMetrics/MappingMetricsFactory.swift
+++ b/Sources/CoreMetrics/MappingMetricsFactory.swift
@@ -35,8 +35,8 @@
 ///   discrepancy only requires attention when correlating local metric handles with data in a remote
 ///   backend.
 public struct MappingMetricsFactory<Upstream: MetricsFactory>: Sendable {
-    private let upstream: Upstream
-    private let transform: @Sendable (String, [(String, String)]) -> (String, [(String, String)])
+    private var upstream: Upstream
+    private var transform: @Sendable (String, [(String, String)]) -> (String, [(String, String)])
 
     /// Create a new `MappingMetricsFactory`.
     ///
@@ -80,8 +80,8 @@ extension MappingMetricsFactory: MetricsFactory {
         label: String,
         dimensions: [(String, String)]
     ) -> CounterHandler {
-        let (newLabel, newDimensions) = transform(label, dimensions)
-        return upstream.makeCounter(label: newLabel, dimensions: newDimensions)
+        let (newLabel, newDimensions) = self.transform(label, dimensions)
+        return self.upstream.makeCounter(label: newLabel, dimensions: newDimensions)
     }
 
     /// Create a backing floating-point counter handler with transformed label and dimensions.
@@ -93,8 +93,8 @@ extension MappingMetricsFactory: MetricsFactory {
         label: String,
         dimensions: [(String, String)]
     ) -> FloatingPointCounterHandler {
-        let (newLabel, newDimensions) = transform(label, dimensions)
-        return upstream.makeFloatingPointCounter(label: newLabel, dimensions: newDimensions)
+        let (newLabel, newDimensions) = self.transform(label, dimensions)
+        return self.upstream.makeFloatingPointCounter(label: newLabel, dimensions: newDimensions)
     }
 
     /// Create a backing meter handler with transformed label and dimensions.
@@ -106,8 +106,8 @@ extension MappingMetricsFactory: MetricsFactory {
         label: String,
         dimensions: [(String, String)]
     ) -> MeterHandler {
-        let (newLabel, newDimensions) = transform(label, dimensions)
-        return upstream.makeMeter(label: newLabel, dimensions: newDimensions)
+        let (newLabel, newDimensions) = self.transform(label, dimensions)
+        return self.upstream.makeMeter(label: newLabel, dimensions: newDimensions)
     }
 
     /// Create a backing recorder handler with transformed label and dimensions.
@@ -121,8 +121,8 @@ extension MappingMetricsFactory: MetricsFactory {
         dimensions: [(String, String)],
         aggregate: Bool
     ) -> RecorderHandler {
-        let (newLabel, newDimensions) = transform(label, dimensions)
-        return upstream.makeRecorder(label: newLabel, dimensions: newDimensions, aggregate: aggregate)
+        let (newLabel, newDimensions) = self.transform(label, dimensions)
+        return self.upstream.makeRecorder(label: newLabel, dimensions: newDimensions, aggregate: aggregate)
     }
 
     /// Create a backing timer handler with transformed label and dimensions.
@@ -134,8 +134,8 @@ extension MappingMetricsFactory: MetricsFactory {
         label: String,
         dimensions: [(String, String)]
     ) -> TimerHandler {
-        let (newLabel, newDimensions) = transform(label, dimensions)
-        return upstream.makeTimer(label: newLabel, dimensions: newDimensions)
+        let (newLabel, newDimensions) = self.transform(label, dimensions)
+        return self.upstream.makeTimer(label: newLabel, dimensions: newDimensions)
     }
 
     /// Invoked when the corresponding counter's `destroy()` function is invoked.
@@ -143,7 +143,7 @@ extension MappingMetricsFactory: MetricsFactory {
     /// - parameters:
     ///   - handler: The handler to be destroyed.
     public func destroyCounter(_ handler: CounterHandler) {
-        upstream.destroyCounter(handler)
+        self.upstream.destroyCounter(handler)
     }
 
     /// Invoked when the corresponding meter's `destroy()` function is invoked.
@@ -151,7 +151,7 @@ extension MappingMetricsFactory: MetricsFactory {
     /// - parameters:
     ///   - handler: The handler to be destroyed.
     public func destroyMeter(_ handler: MeterHandler) {
-        upstream.destroyMeter(handler)
+        self.upstream.destroyMeter(handler)
     }
 
     /// Invoked when the corresponding floating-point counter's `destroy()` function is invoked.
@@ -159,7 +159,7 @@ extension MappingMetricsFactory: MetricsFactory {
     /// - parameters:
     ///   - handler: The handler to be destroyed.
     public func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler) {
-        upstream.destroyFloatingPointCounter(handler)
+        self.upstream.destroyFloatingPointCounter(handler)
     }
 
     /// Invoked when the corresponding recorder's `destroy()` function is invoked.
@@ -167,7 +167,7 @@ extension MappingMetricsFactory: MetricsFactory {
     /// - parameters:
     ///   - handler: The handler to be destroyed.
     public func destroyRecorder(_ handler: RecorderHandler) {
-        upstream.destroyRecorder(handler)
+        self.upstream.destroyRecorder(handler)
     }
 
     /// Invoked when the corresponding timer's `destroy()` function is invoked.
@@ -175,6 +175,6 @@ extension MappingMetricsFactory: MetricsFactory {
     /// - parameters:
     ///   - handler: The handler to be destroyed.
     public func destroyTimer(_ handler: TimerHandler) {
-        upstream.destroyTimer(handler)
+        self.upstream.destroyTimer(handler)
     }
 }

--- a/Tests/MetricsTests/MappingMetricsFactoryTests.swift
+++ b/Tests/MetricsTests/MappingMetricsFactoryTests.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Metrics API open source project
+//
+// Copyright (c) 2018-2026 Apple Inc. and the Swift Metrics API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import MetricsTestKit
+import Testing
+
+@testable import CoreMetrics
+
+struct MappingMetricsFactoryTests {
+    @Test func mapping() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            return (String(label.reversed()), dimensions.map { (String($0.reversed()), $1) })
+        }
+        Counter(
+            label: "foo_bar",
+            dimensions: [("dim1", "abcd")],
+            factory: mapped
+        ).increment()
+        let counter = try #require(upstream.counters.first)
+        #expect(counter.label == "rab_oof")
+        let firstDimension = try #require(counter.dimensions.first)
+        #expect(firstDimension == ("1mid", "abcd"))
+    }
+}

--- a/Tests/MetricsTests/MappingMetricsFactoryTests.swift
+++ b/Tests/MetricsTests/MappingMetricsFactoryTests.swift
@@ -12,26 +12,156 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import MetricsTestKit
 import Testing
 
 @testable import CoreMetrics
 
 struct MappingMetricsFactoryTests {
-    @Test func mapping() throws {
+    // MARK: - All metric types
+
+    @Test func counter() throws {
         let upstream = TestMetrics()
         let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
-            return (String(label.reversed()), dimensions.map { (String($0.reversed()), $1) })
+            ("prefix.\(label)", dimensions + [("env", "test")])
         }
-        Counter(
-            label: "foo_bar",
-            dimensions: [("dim1", "abcd")],
-            factory: mapped
-        ).increment()
-        let counter = try #require(upstream.counters.first)
-        #expect(counter.label == "rab_oof")
-        let firstDimension = try #require(counter.dimensions.first)
-        #expect(firstDimension == ("1mid", "abcd"))
+        let counter = Counter(label: "requests", dimensions: [("method", "GET")], factory: mapped)
+        counter.increment()
+        let testCounter = try upstream.expectCounter("prefix.requests", [("method", "GET"), ("env", "test")])
+        #expect(testCounter.lastValue == 1)
+    }
+
+    @Test func floatingPointCounter() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            ("prefix.\(label)", dimensions + [("env", "test")])
+        }
+        let counter = FloatingPointCounter(label: "bytes", dimensions: [("direction", "in")], factory: mapped)
+        counter.increment(by: 1.5)
+
+        // FloatingPointCounter uses the default implementation which wraps a regular counter.
+        // Verify it reached the upstream factory with the transformed label.
+        let testCounter = try upstream.expectCounter(
+            "prefix.bytes",
+            [("direction", "in"), ("env", "test")]
+        )
+        #expect(testCounter.totalValue == 1)
+    }
+
+    @Test func meter() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            ("prefix.\(label)", dimensions + [("env", "test")])
+        }
+        let meter = Meter(label: "temperature", dimensions: [("unit", "celsius")], factory: mapped)
+        meter.set(42)
+        let testMeter = try upstream.expectMeter("prefix.temperature", [("unit", "celsius"), ("env", "test")])
+        #expect(testMeter.lastValue == 42.0)
+    }
+
+    @Test func recorder() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            ("prefix.\(label)", dimensions + [("env", "test")])
+        }
+        let recorder = Recorder(label: "latency", dimensions: [("path", "/api")], factory: mapped)
+        recorder.record(100)
+        let testRecorder = try upstream.expectRecorder(
+            "prefix.latency",
+            [("path", "/api"), ("env", "test")]
+        )
+        #expect(testRecorder.lastValue == 100.0)
+    }
+
+    @Test func timer() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            ("prefix.\(label)", dimensions + [("env", "test")])
+        }
+        let timer = Timer(label: "duration", dimensions: [("op", "query")], factory: mapped)
+        timer.recordNanoseconds(500)
+        let testTimer = try upstream.expectTimer("prefix.duration", [("op", "query"), ("env", "test")])
+        #expect(testTimer.lastValue == 500)
+    }
+
+    // MARK: - Destroy lifecycle
+
+    @Test func destroyCounter() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            ("prefix.\(label)", dimensions)
+        }
+        let counter = Counter(label: "requests", factory: mapped)
+        counter.increment()
+        #expect(upstream.counters.count == 1)
+        counter.destroy()
+        #expect(upstream.counters.isEmpty)
+    }
+
+    @Test func destroyMeter() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            ("prefix.\(label)", dimensions)
+        }
+        let meter = Meter(label: "temperature", factory: mapped)
+        meter.set(42)
+        #expect(upstream.meters.count == 1)
+        meter.destroy()
+        #expect(upstream.meters.isEmpty)
+    }
+
+    @Test func destroyRecorder() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            ("prefix.\(label)", dimensions)
+        }
+        let recorder = Recorder(label: "latency", factory: mapped)
+        recorder.record(100)
+        #expect(upstream.recorders.count == 1)
+        recorder.destroy()
+        #expect(upstream.recorders.isEmpty)
+    }
+
+    @Test func destroyTimer() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            ("prefix.\(label)", dimensions)
+        }
+        let timer = Timer(label: "duration", factory: mapped)
+        timer.recordNanoseconds(500)
+        #expect(upstream.timers.count == 1)
+        timer.destroy()
+        #expect(upstream.timers.isEmpty)
+    }
+
+    // MARK: - Chaining
+
+    @Test func chainingTransforms() throws {
+        let upstream = TestMetrics()
+        let mapped =
+            upstream
+            .mappingLabelsAndDimensions { label, dimensions in
+                ("app.\(label)", dimensions)
+            }
+            .mappingLabelsAndDimensions { label, dimensions in
+                (label, dimensions + [("region", "us-east-1")])
+            }
+        let counter = Counter(label: "requests", factory: mapped)
+        counter.increment()
+        let testCounter = try upstream.expectCounter("app.requests", [("region", "us-east-1")])
+        #expect(testCounter.lastValue == 1)
+    }
+
+    // MARK: - Identity transform
+
+    @Test func identityTransform() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+            (label, dimensions)
+        }
+        let counter = Counter(label: "requests", dimensions: [("method", "GET")], factory: mapped)
+        counter.increment()
+        let testCounter = try upstream.expectCounter("requests", [("method", "GET")])
+        #expect(testCounter.lastValue == 1)
     }
 }

--- a/Tests/MetricsTests/MappingMetricsFactoryTests.swift
+++ b/Tests/MetricsTests/MappingMetricsFactoryTests.swift
@@ -22,7 +22,7 @@ struct MappingMetricsFactoryTests {
 
     @Test func counter() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions + [("env", "test")])
         }
         let counter = Counter(label: "requests", dimensions: [("method", "GET")], factory: mapped)
@@ -33,14 +33,15 @@ struct MappingMetricsFactoryTests {
 
     @Test func floatingPointCounter() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions + [("env", "test")])
         }
         let counter = FloatingPointCounter(label: "bytes", dimensions: [("direction", "in")], factory: mapped)
         counter.increment(by: 1.5)
 
-        // FloatingPointCounter uses the default implementation which wraps a regular counter.
-        // Verify it reached the upstream factory with the transformed label.
+        // TestMetrics uses the default AccumulatingRoundingFloatingPointCounter, which delegates
+        // to a regular counter internally. The value 1.5 is accumulated and the integer part (1)
+        // is forwarded to the underlying counter.
         let testCounter = try upstream.expectCounter(
             "prefix.bytes",
             [("direction", "in"), ("env", "test")]
@@ -50,7 +51,7 @@ struct MappingMetricsFactoryTests {
 
     @Test func meter() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions + [("env", "test")])
         }
         let meter = Meter(label: "temperature", dimensions: [("unit", "celsius")], factory: mapped)
@@ -61,7 +62,7 @@ struct MappingMetricsFactoryTests {
 
     @Test func recorder() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions + [("env", "test")])
         }
         let recorder = Recorder(label: "latency", dimensions: [("path", "/api")], factory: mapped)
@@ -75,7 +76,7 @@ struct MappingMetricsFactoryTests {
 
     @Test func timer() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions + [("env", "test")])
         }
         let timer = Timer(label: "duration", dimensions: [("op", "query")], factory: mapped)
@@ -88,7 +89,7 @@ struct MappingMetricsFactoryTests {
 
     @Test func destroyCounter() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions)
         }
         let counter = Counter(label: "requests", factory: mapped)
@@ -98,9 +99,22 @@ struct MappingMetricsFactoryTests {
         #expect(upstream.counters.isEmpty)
     }
 
+    @Test func destroyFloatingPointCounter() throws {
+        let upstream = TestMetrics()
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
+            ("prefix.\(label)", dimensions)
+        }
+        let counter = FloatingPointCounter(label: "bytes", factory: mapped)
+        counter.increment(by: 1.5)
+        // The default AccumulatingRoundingFloatingPointCounter delegates to a regular counter.
+        #expect(upstream.counters.count == 1)
+        counter.destroy()
+        #expect(upstream.counters.isEmpty)
+    }
+
     @Test func destroyMeter() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions)
         }
         let meter = Meter(label: "temperature", factory: mapped)
@@ -112,7 +126,7 @@ struct MappingMetricsFactoryTests {
 
     @Test func destroyRecorder() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions)
         }
         let recorder = Recorder(label: "latency", factory: mapped)
@@ -124,7 +138,7 @@ struct MappingMetricsFactoryTests {
 
     @Test func destroyTimer() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             ("prefix.\(label)", dimensions)
         }
         let timer = Timer(label: "duration", factory: mapped)
@@ -140,10 +154,10 @@ struct MappingMetricsFactoryTests {
         let upstream = TestMetrics()
         let mapped =
             upstream
-            .mappingLabelsAndDimensions { label, dimensions in
+            .withLabelAndDimensionsMapping { label, dimensions in
                 ("app.\(label)", dimensions)
             }
-            .mappingLabelsAndDimensions { label, dimensions in
+            .withLabelAndDimensionsMapping { label, dimensions in
                 (label, dimensions + [("region", "us-east-1")])
             }
         let counter = Counter(label: "requests", factory: mapped)
@@ -156,7 +170,7 @@ struct MappingMetricsFactoryTests {
 
     @Test func identityTransform() throws {
         let upstream = TestMetrics()
-        let mapped = upstream.mappingLabelsAndDimensions { label, dimensions in
+        let mapped = upstream.withLabelAndDimensionsMapping { label, dimensions in
             (label, dimensions)
         }
         let counter = Counter(label: "requests", dimensions: [("method", "GET")], factory: mapped)


### PR DESCRIPTION
A utility for renaming labels and dimensions at the metrics factory level.

### Motivation:

Libraries that emit metrics today have no built-in way to let the application customize metric labels or dimensions at
the factory level.

### Modifications:

Introduce a new public type `MappingMetricsFactory` and a convenience method on `MetricsFactory` to allow centralized renaming of all the created metric objects.

### Result:

Libraries like `swift-system-metrics` can be used with various backends requiring different labels naming convention.

