### PR TITLE
Correctly forward multiplexed instruments to factories upon destruction

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -1530,40 +1530,45 @@ public final class MultiplexMetricsHandler: MetricsFactory {
     /// Signal the underlying metrics library that this counter will never be updated again.
     /// - Parameter handler: The counter handler to signal.
     public func destroyCounter(_ handler: CounterHandler) {
-        for factory in self.factories {
-            factory.destroyCounter(handler)
+        guard let mux = handler as? MuxCounter else { return }
+        for (factory, counter) in zip(self.factories, mux.counters) {
+            factory.destroyCounter(counter)
         }
     }
 
     /// Signal the underlying metrics library that this floating point counter will never be updated again.
     /// - Parameter handler: The floating point counter handler to signal.
     public func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler) {
-        for factory in self.factories {
-            factory.destroyFloatingPointCounter(handler)
+        guard let mux = handler as? MuxFloatingPointCounter else { return }
+        for (factory, counter) in zip(self.factories, mux.counters) {
+            factory.destroyFloatingPointCounter(counter)
         }
     }
 
     /// Signal the underlying metrics library that this meter will never be updated again.
     /// - Parameter handler: The meter handler to signal.
     public func destroyMeter(_ handler: MeterHandler) {
-        for factory in self.factories {
-            factory.destroyMeter(handler)
+        guard let mux = handler as? MuxMeter else { return }
+        for (factory, meter) in zip(self.factories, mux.meters) {
+            factory.destroyMeter(meter)
         }
     }
 
     /// Signal the underlying metrics library that this recorder will never be updated again.
     /// - Parameter handler: The recorder handler to signal.
     public func destroyRecorder(_ handler: RecorderHandler) {
-        for factory in self.factories {
-            factory.destroyRecorder(handler)
+        guard let mux = handler as? MuxRecorder else { return }
+        for (factory, recorder) in zip(self.factories, mux.recorders) {
+            factory.destroyRecorder(recorder)
         }
     }
 
     /// Signal the underlying metrics library that this timer will never be updated again.
     /// - Parameter handler: The timer handler to signal.
     public func destroyTimer(_ handler: TimerHandler) {
-        for factory in self.factories {
-            factory.destroyTimer(handler)
+        guard let mux = handler as? MuxTimer else { return }
+        for (factory, timer) in zip(self.factories, mux.timers) {
+            factory.destroyTimer(timer)
         }
     }
 

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -514,7 +514,7 @@ struct MetricsTests {
         #expect(testMeter.values.count == 0, "expected zero values to be ignored")
     }
 
-    @Test func mUX_Counter() throws {
+    @Test func muxCounter() throws {
         // create our test metrics, avoid bootstrapping global MetricsSystem
         let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
         let multiplexFactory = MultiplexMetricsHandler(factories: factories)
@@ -536,7 +536,7 @@ struct MetricsTests {
         }
     }
 
-    @Test func mUX_Meter() throws {
+    @Test func muxMeter() throws {
         // create our test metrics, avoid bootstrapping global MetricsSystem
         let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
         let multiplexFactory = MultiplexMetricsHandler(factories: factories)
@@ -553,7 +553,7 @@ struct MetricsTests {
         }
     }
 
-    @Test func mUX_Recorder() throws {
+    @Test func muxRecorder() throws {
         // create our test metrics, avoid bootstrapping global MetricsSystem
         let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
         let multiplexFactory = MultiplexMetricsHandler(factories: factories)
@@ -570,7 +570,7 @@ struct MetricsTests {
         }
     }
 
-    @Test func mUX_Timer() throws {
+    @Test func muxTimer() throws {
         // create our test metrics, avoid bootstrapping global MetricsSystem
         let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
         let multiplexFactory = MultiplexMetricsHandler(factories: factories)
@@ -589,6 +589,78 @@ struct MetricsTests {
                 timer?.valueInPreferredUnit(atIndex: 0) == Double(seconds) / 60.0,
                 "seconds should be returned as minutes"
             )
+        }
+    }
+
+    @Test func muxCounterDestroy() throws {
+        let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
+        let multiplexFactory = MultiplexMetricsHandler(factories: factories)
+        let counter = Counter(label: UUID().uuidString, factory: multiplexFactory)
+        counter.increment()
+        for factory in factories {
+            #expect(factory.counters.count == 1, "expected counter to be created in each underlying factory")
+        }
+        counter.destroy()
+        for factory in factories {
+            #expect(factory.counters.isEmpty, "expected underlying counter to be destroyed in each factory")
+        }
+    }
+
+    @Test func muxFloatingPointCounterDestroy() throws {
+        let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
+        let multiplexFactory = MultiplexMetricsHandler(factories: factories)
+        let counter = FloatingPointCounter(label: UUID().uuidString, factory: multiplexFactory)
+        counter.increment(by: 1.5)
+        // The default FloatingPointCounter wraps an underlying Counter; the underlying counter
+        // is what ends up registered with each TestMetrics factory.
+        for factory in factories {
+            #expect(factory.counters.count == 1, "expected backing counter to be created in each underlying factory")
+        }
+        counter.destroy()
+        for factory in factories {
+            #expect(factory.counters.isEmpty, "expected backing counter to be destroyed in each factory")
+        }
+    }
+
+    @Test func muxMeterDestroy() throws {
+        let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
+        let multiplexFactory = MultiplexMetricsHandler(factories: factories)
+        let meter = Meter(label: UUID().uuidString, factory: multiplexFactory)
+        meter.set(1.0)
+        for factory in factories {
+            #expect(factory.meters.count == 1, "expected meter to be created in each underlying factory")
+        }
+        meter.destroy()
+        for factory in factories {
+            #expect(factory.meters.isEmpty, "expected underlying meter to be destroyed in each factory")
+        }
+    }
+
+    @Test func muxRecorderDestroy() throws {
+        let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
+        let multiplexFactory = MultiplexMetricsHandler(factories: factories)
+        let recorder = Recorder(label: UUID().uuidString, factory: multiplexFactory)
+        recorder.record(1.0)
+        for factory in factories {
+            #expect(factory.recorders.count == 1, "expected recorder to be created in each underlying factory")
+        }
+        recorder.destroy()
+        for factory in factories {
+            #expect(factory.recorders.isEmpty, "expected underlying recorder to be destroyed in each factory")
+        }
+    }
+
+    @Test func muxTimerDestroy() throws {
+        let factories = [TestMetrics(), TestMetrics(), TestMetrics()]
+        let multiplexFactory = MultiplexMetricsHandler(factories: factories)
+        let timer = Timer(label: UUID().uuidString, factory: multiplexFactory)
+        timer.recordNanoseconds(1)
+        for factory in factories {
+            #expect(factory.timers.count == 1, "expected timer to be created in each underlying factory")
+        }
+        timer.destroy()
+        for factory in factories {
+            #expect(factory.timers.isEmpty, "expected underlying timer to be destroyed in each factory")
         }
     }
 


### PR DESCRIPTION
Correctly forward multiplexed instruments to factories upon destruction.

### Motivation:

Factories inside `MultiplexMetricsHandler` receive `MuxXXX` instruments instead of instruments they created during destruction. They have no idea what to do with them. For example [`swift-otel` silently drops](https://github.com/swift-otel/swift-otel/blob/d1156d2ffc2a890f990b722fdfcbf6b9ae1f0092/Sources/OTel/OTelCore/Metrics/SwiftMetricsFactory/OTLPMetricsFactory.swift#L226) such an unknown instrument without destroying it.

### Modifications:

Forward underlying instruments to the corresponding factories.

### Result:

Multiplexed instruments can be correctly destroyed by their factories.
