### PR TITLE
Change '_handler' from public to package access

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -36,10 +36,11 @@
 /// counter.reset()
 /// ````
 public final class Counter {
-    /// `_handler` and `_factory` are only public to allow access from `MetricsTestKit`.
+    /// `_handler` and `_factory` are only `package` to allow access from `MetricsTestKit`.
     /// Do not consider them part of the public API.
     @_documentation(visibility: internal)
-    public let _handler: CounterHandler
+    @usableFromInline
+    package let _handler: CounterHandler
     @_documentation(visibility: internal)
     @usableFromInline
     package let _factory: MetricsFactory
@@ -162,10 +163,11 @@ extension Counter: CustomStringConvertible {
 /// counter.reset()
 /// ````
 public final class FloatingPointCounter {
-    /// `_handler` and `_factory` are only public to allow access from `MetricsTestKit`.
+    /// `_handler` and `_factory` are only `package` to allow access from `MetricsTestKit`.
     /// Do not consider them part of the public API.
     @_documentation(visibility: internal)
-    public let _handler: FloatingPointCounterHandler
+    @usableFromInline
+    package let _handler: FloatingPointCounterHandler
     @_documentation(visibility: internal)
     @usableFromInline
     package let _factory: MetricsFactory
@@ -314,10 +316,11 @@ public final class Gauge: Recorder, @unchecked Sendable {
 /// meter.record(100)
 /// ```
 public final class Meter {
-    /// `_handler` and `_factory` are only public to allow access from `MetricsTestKit`.
+    /// `_handler` and `_factory` are only `package` to allow access from `MetricsTestKit`.
     /// Do not consider them part of the public API.
     @_documentation(visibility: internal)
-    public let _handler: MeterHandler
+    @usableFromInline
+    package let _handler: MeterHandler
     @usableFromInline
     @_documentation(visibility: internal)
     package let _factory: MetricsFactory
@@ -455,10 +458,11 @@ extension Meter: CustomStringConvertible {
 /// recorder.record(101)
 /// ```
 public class Recorder {
-    /// `_handler` and `_factory` are only public to allow access from `MetricsTestKit`.
+    /// `_handler` and `_factory` are only `package` to allow access from `MetricsTestKit`.
     /// Do not consider them part of the public API.
     @_documentation(visibility: internal)
-    public let _handler: RecorderHandler
+    @usableFromInline
+    package let _handler: RecorderHandler
     @_documentation(visibility: internal)
     @usableFromInline
     package let _factory: MetricsFactory
@@ -645,10 +649,11 @@ public struct TimeUnit: Equatable, Sendable {
 /// ```
 
 public final class Timer {
-    /// `_handler` and `_factory` are only public to allow access from `MetricsTestKit`.
+    /// `_handler` and `_factory` are only `package` to allow access from `MetricsTestKit`.
     /// Do not consider them part of the public API.
     @_documentation(visibility: internal)
-    public let _handler: TimerHandler
+    @usableFromInline
+    package let _handler: TimerHandler
     @_documentation(visibility: internal)
     @usableFromInline
     package let _factory: MetricsFactory


### PR DESCRIPTION
Lower the `_handler` properties from `public` to `package` access, matching `_factory`.

### Motivation:

The `_handler` (and `_factory`) properties on `Counter`, `FloatingPointCounter`, `Meter`, `Recorder`, and `Timer` are not part of the public API. Their doc comments already state "Do not consider them part of the public API" and they are hidden from documentation via `@_documentation(visibility: internal)`. They are only exposed so that `MetricsTestKit` can reach into them.

These properties were declared `public` because they predate the `package` access level. As requested in issue #173 (and the earlier review discussion on #172, where the maintainers asked for `package` to be used), `_factory` was already migrated to `package`. This change finishes the job for the matching `_handler` properties so the testing-only surface is no longer part of the public API.

### Modifications:

- Changed `_handler` on `Counter`, `FloatingPointCounter`, `Meter`, `Recorder`, and `Timer` from `public let` to `@usableFromInline package let`.
- Added `@usableFromInline` because `_handler` is referenced from existing `@inlinable` members (`increment`, `reset`, `record`, `destroy`, ...); this mirrors the existing `@usableFromInline package let _factory` declaration.
- Updated the accompanying doc comments to say the properties are only `package` (instead of "only public") to allow access from `MetricsTestKit`.

### Result:

The `_handler` and `_factory` testing-only properties are now `package` rather than `public`, consistent with their documented "not public API" intent and with the maintainers' request. `MetricsTestKit` continues to access them within the same package, and the full test suite passes (103 tests in 8 suites). Note this lowers the access level of underscore-prefixed, documentation-hidden symbols, so it is technically source-breaking for any code that reached into them directly.

Fixes #173
