### PR TITLE
Add `CustomStringConvertible` to `TestMetrics`

### DIFF
--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -672,11 +672,12 @@ extension TestRecorder: CustomStringConvertible {
 }
 
 extension TestTimer: CustomStringConvertible {
-    /// Shows the label, dimensions, and recorded durations in nanoseconds.
+    /// Shows the label, dimensions, unit, and recorded durations.
     ///
-    /// Values are always rendered in nanoseconds — the unit they are stored in — regardless of any preferred
-    /// unit set via ``preferDisplayUnit(_:)``. Use ``valueInPreferredUnit(atIndex:)`` to read a converted value.
+    /// Durations are always rendered in nanoseconds — the unit they are stored in, as called out by the
+    /// `unit: nanoseconds` field — regardless of any preferred unit set via ``preferDisplayUnit(_:)``. Use
+    /// ``valueInPreferredUnit(atIndex:)`` to read a converted value.
     public var description: String {
-        "TestTimer(\(self.label), dimensions: \(self.dimensions), valuesNanos: \(self.values))"
+        "TestTimer(\(self.label), dimensions: \(self.dimensions), unit: nanoseconds, values: \(self.values))"
     }
 }

--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -604,13 +604,17 @@ extension TestMetrics: CustomStringConvertible {
     /// the output is deterministic across runs. Use this while debugging a test to see what a piece of code
     /// reported; it is intended for humans to read, not for machine parsing.
     public var description: String {
-        // Snapshot each dictionary under the factory lock, then render outside it. Each instrument's own
-        // `description` takes that instrument's lock, and we never hold the factory lock while calling into
-        // one, so there is no nested-lock hazard.
-        let counters = self.lock.withLock { Array(self._counters.values) }
-        let meters = self.lock.withLock { Array(self._meters.values) }
-        let recorders = self.lock.withLock { Array(self._recorders.values) }
-        let timers = self.lock.withLock { Array(self._timers.values) }
+        // Snapshot all instruments under a single factory-lock acquisition, so the dump is a consistent
+        // point-in-time view across kinds, then render outside the lock. Each instrument's own `description`
+        // takes that instrument's lock.
+        let (counters, meters, recorders, timers) = self.lock.withLock {
+            (
+                Array(self._counters.values),
+                Array(self._meters.values),
+                Array(self._recorders.values),
+                Array(self._timers.values)
+            )
+        }
 
         var lines: [String] = []
         func appendGroup<Metric: TestMetric & CustomStringConvertible>(_ title: String, _ items: [Metric]) {

--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -594,3 +594,85 @@ extension TestCounter: @unchecked Sendable {}
 extension TestMeter: @unchecked Sendable {}
 extension TestRecorder: @unchecked Sendable {}
 extension TestTimer: @unchecked Sendable {}
+
+// MARK: - CustomStringConvertible support
+
+extension TestMetrics: CustomStringConvertible {
+    /// A human-readable dump of every live instrument and the values recorded into it.
+    ///
+    /// Instruments are grouped by kind and, within each group, sorted by label and then by dimensions, so
+    /// the output is deterministic across runs. Use this while debugging a test to see what a piece of code
+    /// reported; it is intended for humans to read, not for machine parsing.
+    public var description: String {
+        // Snapshot each dictionary under the factory lock, then render outside it. Each instrument's own
+        // `description` takes that instrument's lock, and we never hold the factory lock while calling into
+        // one, so there is no nested-lock hazard.
+        let counters = self.lock.withLock { Array(self._counters.values) }
+        let meters = self.lock.withLock { Array(self._meters.values) }
+        let recorders = self.lock.withLock { Array(self._recorders.values) }
+        let timers = self.lock.withLock { Array(self._timers.values) }
+
+        var lines: [String] = []
+        func appendGroup<Metric: TestMetric & CustomStringConvertible>(_ title: String, _ items: [Metric]) {
+            guard !items.isEmpty else { return }
+            lines.append("\(title):")
+            for item in items.sorted(by: { Self.isOrderedBefore($0, $1) }) {
+                lines.append("  \(item.description)")
+            }
+        }
+
+        appendGroup("Counters", counters)
+        appendGroup("Meters", meters)
+        appendGroup("Recorders", recorders)
+        appendGroup("Timers", timers)
+
+        return lines.isEmpty ? "TestMetrics(empty)" : "TestMetrics:\n" + lines.joined(separator: "\n")
+    }
+
+    /// Orders two instruments by label, then by their dimensions rendered as a `key=value` list, so that
+    /// instruments stored in an unordered dictionary print in a stable, deterministic order.
+    private static func isOrderedBefore(_ lhs: some TestMetric, _ rhs: some TestMetric) -> Bool {
+        let lhsKey = lhs.key
+        let rhsKey = rhs.key
+        if lhsKey.label != rhsKey.label {
+            return lhsKey.label < rhsKey.label
+        }
+        let lhsDimensions = lhsKey.dimensions.map { "\($0.0)=\($0.1)" }
+        let rhsDimensions = rhsKey.dimensions.map { "\($0.0)=\($0.1)" }
+        return lhsDimensions.lexicographicallyPrecedes(rhsDimensions)
+    }
+}
+
+extension TestCounter: CustomStringConvertible {
+    /// Shows the label, dimensions, every recorded increment, and their running total.
+    public var description: String {
+        let values = self.values
+        return "TestCounter(\(self.label), dimensions: \(self.dimensions), "
+            + "values: \(values), total: \(values.reduce(0, +)))"
+    }
+}
+
+extension TestMeter: CustomStringConvertible {
+    /// Shows the label, dimensions, and recorded values in observation order.
+    public var description: String {
+        "TestMeter(\(self.label), dimensions: \(self.dimensions), values: \(self.values))"
+    }
+}
+
+extension TestRecorder: CustomStringConvertible {
+    /// Shows the label, dimensions, aggregate flag, and recorded values.
+    public var description: String {
+        "TestRecorder(\(self.label), dimensions: \(self.dimensions), "
+            + "aggregate: \(self.aggregate), values: \(self.values))"
+    }
+}
+
+extension TestTimer: CustomStringConvertible {
+    /// Shows the label, dimensions, and recorded durations in nanoseconds.
+    ///
+    /// Values are always rendered in nanoseconds — the unit they are stored in — regardless of any preferred
+    /// unit set via ``preferDisplayUnit(_:)``. Use ``valueInPreferredUnit(atIndex:)`` to read a converted value.
+    public var description: String {
+        "TestTimer(\(self.label), dimensions: \(self.dimensions), valuesNanos: \(self.values))"
+    }
+}

--- a/Tests/MetricsTests/TestMetricsDescriptionTests.swift
+++ b/Tests/MetricsTests/TestMetricsDescriptionTests.swift
@@ -65,7 +65,7 @@ struct TestMetricsDescriptionTests {
         let testTimer = try metrics.expectTimer("latency", [])
         // A preferred display unit must not change the printed (stored) nanosecond values.
         testTimer.preferDisplayUnit(.milliseconds)
-        #expect(testTimer.description == "TestTimer(latency, dimensions: [], valuesNanos: [1000000])")
+        #expect(testTimer.description == "TestTimer(latency, dimensions: [], unit: nanoseconds, values: [1000000])")
     }
 
     @Test func metricsDescriptionGroupsAndSortsDeterministically() throws {

--- a/Tests/MetricsTests/TestMetricsDescriptionTests.swift
+++ b/Tests/MetricsTests/TestMetricsDescriptionTests.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Metrics API open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+import Foundation
+import MetricsTestKit
+import Testing
+
+struct TestMetricsDescriptionTests {
+    @Test func emptyMetricsDescribesAsEmpty() {
+        #expect(TestMetrics().description == "TestMetrics(empty)")
+    }
+
+    @Test func counterDescriptionShowsValuesAndTotal() throws {
+        let metrics = TestMetrics()
+        let counter = metrics.makeCounter(label: "requests", dimensions: [("method", "GET")])
+        counter.increment(by: 10)
+        counter.increment(by: 5)
+
+        let testCounter = try metrics.expectCounter("requests", [("method", "GET")])
+        #expect(
+            testCounter.description
+                == #"TestCounter(requests, dimensions: [("method", "GET")], values: [10, 5], total: 15)"#
+        )
+    }
+
+    @Test func meterDescriptionShowsValues() throws {
+        let metrics = TestMetrics()
+        let meter = metrics.makeMeter(label: "queue.depth", dimensions: [])
+        meter.set(3.0)
+        meter.set(7.0)
+
+        let testMeter = try metrics.expectMeter("queue.depth", [])
+        #expect(testMeter.description == "TestMeter(queue.depth, dimensions: [], values: [3.0, 7.0])")
+    }
+
+    @Test func recorderDescriptionShowsAggregateAndValues() throws {
+        let metrics = TestMetrics()
+        let recorder = metrics.makeRecorder(label: "response.size", dimensions: [], aggregate: true)
+        recorder.record(1024.0)
+
+        let testRecorder = try metrics.expectRecorder("response.size", [])
+        #expect(
+            testRecorder.description
+                == "TestRecorder(response.size, dimensions: [], aggregate: true, values: [1024.0])"
+        )
+    }
+
+    @Test func timerDescriptionShowsRawNanosecondsIgnoringDisplayUnit() throws {
+        let metrics = TestMetrics()
+        let timer = metrics.makeTimer(label: "latency", dimensions: [])
+        timer.recordNanoseconds(1_000_000)
+
+        let testTimer = try metrics.expectTimer("latency", [])
+        // A preferred display unit must not change the printed (stored) nanosecond values.
+        testTimer.preferDisplayUnit(.milliseconds)
+        #expect(testTimer.description == "TestTimer(latency, dimensions: [], valuesNanos: [1000000])")
+    }
+
+    @Test func metricsDescriptionGroupsAndSortsDeterministically() throws {
+        let metrics = TestMetrics()
+        metrics.makeCounter(label: "zebra", dimensions: []).increment(by: 1)
+        metrics.makeCounter(label: "alpha", dimensions: []).increment(by: 2)
+        metrics.makeTimer(label: "latency", dimensions: []).recordNanoseconds(42)
+
+        let description = metrics.description
+
+        // The output is identical across calls — no dependence on dictionary iteration order.
+        #expect(description == metrics.description)
+
+        // Groups are ordered: counters before timers.
+        let countersHeader = try #require(description.range(of: "Counters:"))
+        let timersHeader = try #require(description.range(of: "Timers:"))
+        #expect(countersHeader.lowerBound < timersHeader.lowerBound)
+
+        // Within the counters group, instruments sort by label: "alpha" before "zebra".
+        let alpha = try #require(description.range(of: "alpha"))
+        let zebra = try #require(description.range(of: "zebra"))
+        #expect(alpha.lowerBound < zebra.lowerBound)
+    }
+
+    @Test func metricsDescriptionSortsByDimensionsWhenLabelsMatch() throws {
+        let metrics = TestMetrics()
+        metrics.makeCounter(label: "http", dimensions: [("status", "500")]).increment(by: 1)
+        metrics.makeCounter(label: "http", dimensions: [("status", "200")]).increment(by: 1)
+
+        let description = metrics.description
+
+        // Same label, so the dimensions break the tie: "status=200" sorts before "status=500".
+        let status200 = try #require(description.range(of: "200"))
+        let status500 = try #require(description.range(of: "500"))
+        #expect(status200.lowerBound < status500.lowerBound)
+    }
+}


### PR DESCRIPTION
Currently, when testing, there is not way to print out the counter to see what is in it.

### Motivation:

Having a way to print a human-readable representation of the `TestMetrics` is useful during the debugging.

### Modifications:

Conform `TestMetrics` to `CustomStringConvertible` and implement human-readable representation of its content.

### Result:

`TestMetrics` object can now be printed and produces a string representation looking like this:

```
// TestMetrics:
// Counters:
//   TestCounter(requests, dimensions: [("method", "GET")], values: [10, 5], total: 15)
// Recorders:
//   TestRecorder(response.size, dimensions: [], aggregate: true, values: [1024.0])
// Timers:
//   TestTimer(latency, dimensions: [], valuesNanos: [1000000])
```
