### PR TITLE
Support building with CMake

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,6 +29,20 @@ jobs:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
 
+  cmake-lists:
+    name: Check cmake lists
+    uses: apple/swift-nio/.github/workflows/cmake_tests.yml@main
+    with:
+      image: "swift:6.1-noble"
+      update_cmake_lists_config: >-
+        {
+          "targets": [
+            { "name": "CoreMetrics", "type": "source", "exceptions": [] },
+            { "name": "Metrics", "type": "source", "exceptions": [] },
+            { "name": "MetricsTestKit", "type": "source", "exceptions": [] }
+          ]
+        }
+
   macos-tests:
     name: macOS tests
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/build
 /Packages
 /*.xcodeproj
 .xcode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Metrics API open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+cmake_minimum_required(VERSION 3.19)
+
+project(SwiftMetrics
+  LANGUAGES Swift)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
+include(SwiftSupport)
+
+option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+set(CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
+
+# Toolchain vended dependencies
+find_package(dispatch CONFIG)
+find_package(Foundation CONFIG)
+
+add_subdirectory(Sources)
+add_subdirectory(cmake/modules)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,17 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Metrics API open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_subdirectory(CoreMetrics)
+add_subdirectory(Metrics)
+add_subdirectory(MetricsTestKit)

--- a/Sources/CoreMetrics/CMakeLists.txt
+++ b/Sources/CoreMetrics/CMakeLists.txt
@@ -1,0 +1,29 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Metrics API open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_library(CoreMetrics
+  "Locks.swift"
+  "MappingMetricsFactory.swift"
+  "Metrics.swift"
+  "WithMetricsFactory.swift"
+)
+
+target_compile_options(CoreMetrics PRIVATE
+  "SHELL:-package-name swift-metrics")
+
+set_target_properties(CoreMetrics PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+_install_target(CoreMetrics)
+set_property(GLOBAL APPEND PROPERTY SWIFT_METRICS_EXPORTS CoreMetrics)

--- a/Sources/Metrics/CMakeLists.txt
+++ b/Sources/Metrics/CMakeLists.txt
@@ -1,0 +1,31 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Metrics API open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_library(Metrics
+  "Metrics.swift"
+)
+
+target_link_libraries(Metrics PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
+  CoreMetrics)
+
+target_compile_options(Metrics PRIVATE
+  "SHELL:-package-name swift-metrics")
+
+set_target_properties(Metrics PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+_install_target(Metrics)
+set_property(GLOBAL APPEND PROPERTY SWIFT_METRICS_EXPORTS Metrics)

--- a/Sources/MetricsTestKit/CMakeLists.txt
+++ b/Sources/MetricsTestKit/CMakeLists.txt
@@ -1,0 +1,31 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Metrics API open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_library(MetricsTestKit
+  "StreamMetricsFactory.swift"
+  "TestMetrics.swift"
+)
+
+target_link_libraries(MetricsTestKit PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
+  Metrics)
+
+target_compile_options(MetricsTestKit PRIVATE
+  "SHELL:-package-name swift-metrics")
+
+set_target_properties(MetricsTestKit PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+_install_target(MetricsTestKit)
+set_property(GLOBAL APPEND PROPERTY SWIFT_METRICS_EXPORTS MetricsTestKit)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,20 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Metrics API open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set(SWIFT_METRICS_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/SwiftMetricsExports.cmake)
+configure_file(SwiftMetricsConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/SwiftMetricsConfig.cmake)
+
+get_property(SWIFT_METRICS_EXPORTS GLOBAL PROPERTY SWIFT_METRICS_EXPORTS)
+export(TARGETS ${SWIFT_METRICS_EXPORTS} FILE ${SWIFT_METRICS_EXPORTS_FILE})

--- a/cmake/modules/SwiftMetricsConfig.cmake.in
+++ b/cmake/modules/SwiftMetricsConfig.cmake.in
@@ -1,0 +1,17 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Metrics API open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+if(NOT TARGET SwiftMetrics)
+  include(@SWIFT_METRICS_EXPORTS_FILE@)
+endif()

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,73 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Metrics API open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+if(NOT SwiftMetrics_SWIFTMODULE_TRIPLE)
+  set(target_info_cmd "${CMAKE_Swift_COMPILER}" -print-target-info)
+  if(CMAKE_Swift_COMPILER_TARGET)
+    list(APPEND target_info_cmd -target ${CMAKE_Swift_COMPILER_TARGET})
+  endif()
+  execute_process(COMMAND ${target_info_cmd} OUTPUT_VARIABLE target_info)
+  string(JSON module_triple GET "${target_info}" "target" "moduleTriple")
+  set(SwiftMetrics_SWIFTMODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used to install Swift module files")
+  mark_as_advanced(SwiftMetrics_SWIFTMODULE_TRIPLE)
+  message(CONFIGURE_LOG "Swift module triple: ${module_triple}")
+endif()
+
+# Returns the os name in a variable
+#
+# Usage:
+#   get_swift_host_os(result_var_name)
+#
+#
+# Sets ${result_var_name} with the converted OS name derived from
+# CMAKE_SYSTEM_NAME.
+function(get_swift_host_os result_var_name)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(${result_var_name} macosx PARENT_SCOPE)
+  else()
+    string(TOLOWER ${CMAKE_SYSTEM_NAME} cmake_system_name_lc)
+    set(${result_var_name} ${cmake_system_name_lc} PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(_install_target module)
+  get_swift_host_os(swift_os)
+  get_target_property(type ${module} TYPE)
+
+  if(type STREQUAL STATIC_LIBRARY)
+    set(swift swift_static)
+  else()
+    set(swift swift)
+  endif()
+
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION lib/${swift}/${swift_os}
+    LIBRARY DESTINATION lib/${swift}/${swift_os}
+    RUNTIME DESTINATION bin)
+  if(type STREQUAL EXECUTABLE)
+    return()
+  endif()
+
+  get_target_property(module_name ${module} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${module})
+  endif()
+
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftMetrics_SWIFTMODULE_TRIPLE}.swiftdoc)
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftMetrics_SWIFTMODULE_TRIPLE}.swiftmodule)
+endfunction()


### PR DESCRIPTION
swift-metrics had no CMake build, so CMake-based consumers such as SwiftPM's own build could not pick it up the way they pick up swift-certificates or swift-argument-parser. This adds a CMake build for the three library targets, `CoreMetrics`, `Metrics` and `MetricsTestKit`, laid out the same way as swift-certificates: a root `CMakeLists.txt`, one per target under `Sources`, and `cmake/modules` carrying `SwiftSupport.cmake` plus the exported config template. The targets are compiled with `-package-name swift-metrics` so the `package` declarations in `CoreMetrics` stay visible to `Metrics` and `MetricsTestKit`, matching what SwiftPM passes.

I also wired up the shared `apple/swift-nio/.github/workflows/cmake_tests.yml` job so the file lists cannot drift from the source tree, and added `/build` to `.gitignore` since that is the directory the shared cmake-build script uses.

Verified locally with CMake 4.4 and Ninja on macOS: a shared-library configure and build succeeds for all three targets, a `BUILD_SHARED_LIBS=NO` configure and build succeeds, and `cmake --install` lays down the archives plus the `.swiftmodule` and `.swiftdoc` files under `lib/swift_static/macosx`. The generated source lists were checked against what `scripts/update-cmake-lists.sh` produces for each target.

Fixes #232