### PR TITLE
Add MetricDescriptor and descriptor-based factory APIs (PoC for #236)

### DIFF
--- a/Sources/CoreMetrics/CMakeLists.txt
+++ b/Sources/CoreMetrics/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_library(CoreMetrics
   "Locks.swift"
   "MappingMetricsFactory.swift"
+  "MetricDescriptor.swift"
   "Metrics.swift"
   "WithMetricsFactory.swift"
 )

--- a/Sources/CoreMetrics/MappingMetricsFactory.swift
+++ b/Sources/CoreMetrics/MappingMetricsFactory.swift
@@ -138,6 +138,56 @@ extension MappingMetricsFactory: MetricsFactory {
         return self.upstream.makeTimer(label: newLabel, dimensions: newDimensions)
     }
 
+    /// Create a backing counter handler with transformed label and dimensions, preserving the description.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `CounterHandler`.
+    public func makeCounter(descriptor: MetricDescriptor) -> CounterHandler {
+        self.upstream.makeCounter(descriptor: self.transform(descriptor))
+    }
+
+    /// Create a backing floating-point counter handler with transformed label and dimensions, preserving the description.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `FloatingPointCounterHandler`.
+    public func makeFloatingPointCounter(descriptor: MetricDescriptor) -> FloatingPointCounterHandler {
+        self.upstream.makeFloatingPointCounter(descriptor: self.transform(descriptor))
+    }
+
+    /// Create a backing meter handler with transformed label and dimensions, preserving the description.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `MeterHandler`.
+    public func makeMeter(descriptor: MetricDescriptor) -> MeterHandler {
+        self.upstream.makeMeter(descriptor: self.transform(descriptor))
+    }
+
+    /// Create a backing recorder handler with transformed label and dimensions, preserving the description.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `RecorderHandler`.
+    ///   - aggregate: A Boolean value that indicates whether to aggregate values.
+    public func makeRecorder(descriptor: MetricDescriptor, aggregate: Bool) -> RecorderHandler {
+        self.upstream.makeRecorder(descriptor: self.transform(descriptor), aggregate: aggregate)
+    }
+
+    /// Create a backing timer handler with transformed label and dimensions, preserving the description.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `TimerHandler`.
+    public func makeTimer(descriptor: MetricDescriptor) -> TimerHandler {
+        self.upstream.makeTimer(descriptor: self.transform(descriptor))
+    }
+
+    /// Applies the label and dimensions transformation to a descriptor, preserving all other metadata.
+    private func transform(_ descriptor: MetricDescriptor) -> MetricDescriptor {
+        let (newLabel, newDimensions) = self.transform(descriptor.label, descriptor.dimensions)
+        var newDescriptor = descriptor
+        newDescriptor.label = newLabel
+        newDescriptor.dimensions = newDimensions
+        return newDescriptor
+    }
+
     /// Invoked when the corresponding counter's `destroy()` function is invoked.
     ///
     /// - parameters:

--- a/Sources/CoreMetrics/MetricDescriptor.swift
+++ b/Sources/CoreMetrics/MetricDescriptor.swift
@@ -1,0 +1,295 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Metrics API open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - MetricDescriptor
+
+/// A description of a metric's identity and metadata.
+///
+/// A `MetricDescriptor` bundles everything needed to create a metric — its label, dimensions,
+/// and optional human-readable metadata such as a ``description`` — into a single value that is
+/// easy to evolve without breaking the ``MetricsFactory`` API.
+///
+/// Backends can map ``description`` to their native concept of metric help text, for example a
+/// `HELP` line in Prometheus/OpenMetrics exposition, or the `description` field of an
+/// OpenTelemetry instrument.
+///
+/// ```swift
+/// let counter = Counter(
+///     descriptor: MetricDescriptor(
+///         label: "http_requests_total",
+///         dimensions: [("method", "GET")],
+///         description: "Total number of HTTP requests received."
+///     )
+/// )
+/// ```
+public struct MetricDescriptor: Sendable {
+    /// The label (name) of the metric.
+    public var label: String
+    /// The dimensions of the metric, as `(name, value)` tuples.
+    public var dimensions: [(String, String)]
+    /// An optional human-readable description of what the metric measures.
+    ///
+    /// Backends are encouraged to surface this as their native help/description metadata,
+    /// for example a Prometheus `HELP` line or an OpenTelemetry instrument description.
+    /// The description is metadata only: it is not a dimension and does not contribute to
+    /// the metric's identity or cardinality.
+    public var description: String?
+
+    /// Create a new metric descriptor.
+    ///
+    /// - parameters:
+    ///   - label: The label (name) of the metric.
+    ///   - dimensions: The dimensions of the metric, as `(name, value)` tuples.
+    ///   - description: An optional human-readable description of what the metric measures.
+    public init(label: String, dimensions: [(String, String)] = [], description: String? = nil) {
+        self.label = label
+        self.dimensions = dimensions
+        self.description = description
+    }
+}
+
+extension MetricDescriptor: Equatable {
+    public static func == (lhs: MetricDescriptor, rhs: MetricDescriptor) -> Bool {
+        lhs.label == rhs.label
+            && lhs.dimensions.count == rhs.dimensions.count
+            && zip(lhs.dimensions, rhs.dimensions).allSatisfy { $0.0 == $1.0 && $0.1 == $1.1 }
+            && lhs.description == rhs.description
+    }
+}
+
+// MARK: - MetricsFactory default implementations
+
+extension MetricsFactory {
+    /// Create a backing counter handler from a descriptor.
+    ///
+    /// The default implementation forwards the descriptor's label and dimensions to
+    /// ``MetricsFactory/makeCounter(label:dimensions:)``, discarding the description.
+    /// Backends that can surface metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `CounterHandler`.
+    public func makeCounter(descriptor: MetricDescriptor) -> CounterHandler {
+        self.makeCounter(label: descriptor.label, dimensions: descriptor.dimensions)
+    }
+
+    /// Create a backing floating-point counter handler from a descriptor.
+    ///
+    /// The default implementation forwards the descriptor's label and dimensions to
+    /// ``MetricsFactory/makeFloatingPointCounter(label:dimensions:)``, discarding the description.
+    /// Backends that can surface metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `FloatingPointCounterHandler`.
+    public func makeFloatingPointCounter(descriptor: MetricDescriptor) -> FloatingPointCounterHandler {
+        self.makeFloatingPointCounter(label: descriptor.label, dimensions: descriptor.dimensions)
+    }
+
+    /// Create a backing meter handler from a descriptor.
+    ///
+    /// The default implementation forwards the descriptor's label and dimensions to
+    /// ``MetricsFactory/makeMeter(label:dimensions:)``, discarding the description.
+    /// Backends that can surface metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `MeterHandler`.
+    public func makeMeter(descriptor: MetricDescriptor) -> MeterHandler {
+        self.makeMeter(label: descriptor.label, dimensions: descriptor.dimensions)
+    }
+
+    /// Create a backing recorder handler from a descriptor.
+    ///
+    /// The default implementation forwards the descriptor's label and dimensions to
+    /// ``MetricsFactory/makeRecorder(label:dimensions:aggregate:)``, discarding the description.
+    /// Backends that can surface metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `RecorderHandler`.
+    ///   - aggregate: Whether the returned handler should summarize recorded values as a distribution.
+    public func makeRecorder(descriptor: MetricDescriptor, aggregate: Bool) -> RecorderHandler {
+        self.makeRecorder(label: descriptor.label, dimensions: descriptor.dimensions, aggregate: aggregate)
+    }
+
+    /// Create a backing timer handler from a descriptor.
+    ///
+    /// The default implementation forwards the descriptor's label and dimensions to
+    /// ``MetricsFactory/makeTimer(label:dimensions:)``, discarding the description.
+    /// Backends that can surface metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `TimerHandler`.
+    public func makeTimer(descriptor: MetricDescriptor) -> TimerHandler {
+        self.makeTimer(label: descriptor.label, dimensions: descriptor.dimensions)
+    }
+}
+
+// MARK: - Descriptor-based user API
+
+extension Counter {
+    /// Create a new counter from a descriptor, using a custom metrics factory that you provide.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Counter`.
+    ///   - factory: The custom metrics factory.
+    public convenience init(descriptor: MetricDescriptor, factory: MetricsFactory) {
+        let handler = factory.makeCounter(descriptor: descriptor)
+        self.init(label: descriptor.label, dimensions: descriptor.dimensions, handler: handler, factory: factory)
+    }
+
+    /// Create a new counter from a descriptor.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Counter`.
+    public convenience init(descriptor: MetricDescriptor) {
+        self.init(descriptor: descriptor, factory: MetricsSystem.factory)
+    }
+}
+
+extension FloatingPointCounter {
+    /// Create a new floating-point counter from a descriptor, using a custom metrics factory that you provide.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `FloatingPointCounter`.
+    ///   - factory: The custom metrics factory.
+    public convenience init(descriptor: MetricDescriptor, factory: MetricsFactory) {
+        let handler = factory.makeFloatingPointCounter(descriptor: descriptor)
+        self.init(label: descriptor.label, dimensions: descriptor.dimensions, handler: handler, factory: factory)
+    }
+
+    /// Create a new floating-point counter from a descriptor.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `FloatingPointCounter`.
+    public convenience init(descriptor: MetricDescriptor) {
+        self.init(descriptor: descriptor, factory: MetricsSystem.factory)
+    }
+}
+
+extension Meter {
+    /// Create a new meter from a descriptor, using a custom metrics factory that you provide.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Meter`.
+    ///   - factory: The custom metrics factory.
+    public convenience init(descriptor: MetricDescriptor, factory: MetricsFactory) {
+        let handler = factory.makeMeter(descriptor: descriptor)
+        self.init(label: descriptor.label, dimensions: descriptor.dimensions, handler: handler, factory: factory)
+    }
+
+    /// Create a new meter from a descriptor.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Meter`.
+    public convenience init(descriptor: MetricDescriptor) {
+        self.init(descriptor: descriptor, factory: MetricsSystem.factory)
+    }
+}
+
+extension Recorder {
+    /// Create a new recorder from a descriptor, using a custom metrics factory that you provide.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Recorder`.
+    ///   - aggregate: A Boolean value that indicates whether to aggregate values.
+    ///   - factory: The custom metrics factory.
+    public convenience init(descriptor: MetricDescriptor, aggregate: Bool = true, factory: MetricsFactory) {
+        let handler = factory.makeRecorder(descriptor: descriptor, aggregate: aggregate)
+        self.init(
+            label: descriptor.label,
+            dimensions: descriptor.dimensions,
+            aggregate: aggregate,
+            handler: handler,
+            factory: factory
+        )
+    }
+
+    /// Create a new recorder from a descriptor.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Recorder`.
+    ///   - aggregate: A Boolean value that indicates whether to aggregate values.
+    public convenience init(descriptor: MetricDescriptor, aggregate: Bool = true) {
+        self.init(descriptor: descriptor, aggregate: aggregate, factory: MetricsSystem.factory)
+    }
+}
+
+extension Gauge {
+    /// Create a new gauge from a descriptor, using a custom metrics factory that you provide.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Gauge`.
+    ///   - factory: The custom metrics factory.
+    public convenience init(descriptor: MetricDescriptor, factory: MetricsFactory) {
+        let handler = factory.makeRecorder(descriptor: descriptor, aggregate: false)
+        self.init(
+            label: descriptor.label,
+            dimensions: descriptor.dimensions,
+            aggregate: false,
+            handler: handler,
+            factory: factory
+        )
+    }
+
+    /// Create a new gauge from a descriptor.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Gauge`.
+    public convenience init(descriptor: MetricDescriptor) {
+        self.init(descriptor: descriptor, factory: MetricsSystem.factory)
+    }
+}
+
+extension Timer {
+    /// Create a new timer from a descriptor, using a custom metrics factory that you provide.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Timer`.
+    ///   - factory: The custom factory.
+    public convenience init(descriptor: MetricDescriptor, factory: MetricsFactory) {
+        let handler = factory.makeTimer(descriptor: descriptor)
+        self.init(label: descriptor.label, dimensions: descriptor.dimensions, handler: handler, factory: factory)
+    }
+
+    /// Create a new timer from a descriptor.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Timer`.
+    public convenience init(descriptor: MetricDescriptor) {
+        self.init(descriptor: descriptor, factory: MetricsSystem.factory)
+    }
+
+    /// Create a new timer from a descriptor, with a preferred display unit.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Timer`.
+    ///   - displayUnit: A hint to the backend responsible for presenting the data of the preferred display unit. This is not guaranteed to be supported by all backends.
+    ///   - factory: The custom factory.
+    public convenience init(
+        descriptor: MetricDescriptor,
+        preferredDisplayUnit displayUnit: TimeUnit,
+        factory: MetricsFactory
+    ) {
+        let handler = factory.makeTimer(descriptor: descriptor)
+        handler.preferDisplayUnit(displayUnit)
+        self.init(label: descriptor.label, dimensions: descriptor.dimensions, handler: handler, factory: factory)
+    }
+
+    /// Create a new timer from a descriptor, with a preferred display unit.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `Timer`.
+    ///   - displayUnit: A hint to the backend responsible for presenting the data of the preferred display unit. This is not guaranteed to be supported by all backends.
+    public convenience init(descriptor: MetricDescriptor, preferredDisplayUnit displayUnit: TimeUnit) {
+        self.init(descriptor: descriptor, preferredDisplayUnit: displayUnit, factory: MetricsSystem.factory)
+    }
+}

--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -1097,6 +1097,58 @@ public protocol MetricsFactory: _SwiftMetricsSendableProtocol {
     ///   - dimensions: The dimensions for the `TimerHandler`, as `(name, value)` tuples.
     func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler
 
+    /// Create a backing counter handler from a descriptor.
+    ///
+    /// A default implementation is provided which forwards the descriptor's label and dimensions to
+    /// ``makeCounter(label:dimensions:)``, discarding the description. Backends that can surface
+    /// metric descriptions (for example as a Prometheus `HELP` line or an OpenTelemetry instrument
+    /// description) should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `CounterHandler`.
+    func makeCounter(descriptor: MetricDescriptor) -> CounterHandler
+
+    /// Create a backing floating-point counter handler from a descriptor.
+    ///
+    /// A default implementation is provided which forwards the descriptor's label and dimensions to
+    /// ``makeFloatingPointCounter(label:dimensions:)``, discarding the description. Backends that can
+    /// surface metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `FloatingPointCounterHandler`.
+    func makeFloatingPointCounter(descriptor: MetricDescriptor) -> FloatingPointCounterHandler
+
+    /// Create a backing meter handler from a descriptor.
+    ///
+    /// A default implementation is provided which forwards the descriptor's label and dimensions to
+    /// ``makeMeter(label:dimensions:)``, discarding the description. Backends that can surface
+    /// metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `MeterHandler`.
+    func makeMeter(descriptor: MetricDescriptor) -> MeterHandler
+
+    /// Create a backing recorder handler from a descriptor.
+    ///
+    /// A default implementation is provided which forwards the descriptor's label and dimensions to
+    /// ``makeRecorder(label:dimensions:aggregate:)``, discarding the description. Backends that can
+    /// surface metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `RecorderHandler`.
+    ///   - aggregate: Whether the returned handler should summarize recorded values as a distribution.
+    func makeRecorder(descriptor: MetricDescriptor, aggregate: Bool) -> RecorderHandler
+
+    /// Create a backing timer handler from a descriptor.
+    ///
+    /// A default implementation is provided which forwards the descriptor's label and dimensions to
+    /// ``makeTimer(label:dimensions:)``, discarding the description. Backends that can surface
+    /// metric descriptions should implement this method.
+    ///
+    /// - parameters:
+    ///   - descriptor: The descriptor for the `TimerHandler`.
+    func makeTimer(descriptor: MetricDescriptor) -> TimerHandler
+
     /// Invoked when the corresponding counter's `destroy()` function is invoked.
     ///
     /// Upon receiving this signal the factory may eagerly release any resources related to this counter.
@@ -1543,6 +1595,42 @@ public final class MultiplexMetricsHandler: MetricsFactory {
         MuxTimer(factories: self.factories, label: label, dimensions: dimensions)
     }
 
+    /// Creates a new counter handler, forwarding the descriptor to all underlying factories.
+    /// - Parameters:
+    ///   - descriptor: The descriptor for the `CounterHandler`.
+    public func makeCounter(descriptor: MetricDescriptor) -> CounterHandler {
+        MuxCounter(factories: self.factories, descriptor: descriptor)
+    }
+
+    /// Creates a new floating point counter handler, forwarding the descriptor to all underlying factories.
+    /// - Parameters:
+    ///   - descriptor: The descriptor for the `FloatingPointCounterHandler`.
+    public func makeFloatingPointCounter(descriptor: MetricDescriptor) -> FloatingPointCounterHandler {
+        MuxFloatingPointCounter(factories: self.factories, descriptor: descriptor)
+    }
+
+    /// Creates a new meter handler, forwarding the descriptor to all underlying factories.
+    /// - Parameters:
+    ///   - descriptor: The descriptor for the `MeterHandler`.
+    public func makeMeter(descriptor: MetricDescriptor) -> MeterHandler {
+        MuxMeter(factories: self.factories, descriptor: descriptor)
+    }
+
+    /// Creates a new recorder handler, forwarding the descriptor to all underlying factories.
+    /// - Parameters:
+    ///   - descriptor: The descriptor for the `RecorderHandler`.
+    ///   - aggregate: A Boolean value that indicates whether to aggregate values.
+    public func makeRecorder(descriptor: MetricDescriptor, aggregate: Bool) -> RecorderHandler {
+        MuxRecorder(factories: self.factories, descriptor: descriptor, aggregate: aggregate)
+    }
+
+    /// Creates a new timer handler, forwarding the descriptor to all underlying factories.
+    /// - Parameters:
+    ///   - descriptor: The descriptor for the `TimerHandler`.
+    public func makeTimer(descriptor: MetricDescriptor) -> TimerHandler {
+        MuxTimer(factories: self.factories, descriptor: descriptor)
+    }
+
     /// Signal the underlying metrics library that this counter will never be updated again.
     /// - Parameter handler: The counter handler to signal.
     public func destroyCounter(_ handler: CounterHandler) {
@@ -1594,6 +1682,10 @@ public final class MultiplexMetricsHandler: MetricsFactory {
             self.counters = factories.map { $0.makeCounter(label: label, dimensions: dimensions) }
         }
 
+        public init(factories: [MetricsFactory], descriptor: MetricDescriptor) {
+            self.counters = factories.map { $0.makeCounter(descriptor: descriptor) }
+        }
+
         func increment(by amount: Int64) {
             for counter in self.counters { counter.increment(by: amount) }
         }
@@ -1609,6 +1701,10 @@ public final class MultiplexMetricsHandler: MetricsFactory {
             self.counters = factories.map { $0.makeFloatingPointCounter(label: label, dimensions: dimensions) }
         }
 
+        public init(factories: [MetricsFactory], descriptor: MetricDescriptor) {
+            self.counters = factories.map { $0.makeFloatingPointCounter(descriptor: descriptor) }
+        }
+
         func increment(by amount: Double) {
             for counter in self.counters { counter.increment(by: amount) }
         }
@@ -1622,6 +1718,10 @@ public final class MultiplexMetricsHandler: MetricsFactory {
         let meters: [MeterHandler]
         public init(factories: [MetricsFactory], label: String, dimensions: [(String, String)]) {
             self.meters = factories.map { $0.makeMeter(label: label, dimensions: dimensions) }
+        }
+
+        public init(factories: [MetricsFactory], descriptor: MetricDescriptor) {
+            self.meters = factories.map { $0.makeMeter(descriptor: descriptor) }
         }
 
         func set(_ value: Int64) {
@@ -1649,6 +1749,10 @@ public final class MultiplexMetricsHandler: MetricsFactory {
             }
         }
 
+        public init(factories: [MetricsFactory], descriptor: MetricDescriptor, aggregate: Bool) {
+            self.recorders = factories.map { $0.makeRecorder(descriptor: descriptor, aggregate: aggregate) }
+        }
+
         func record(_ value: Int64) {
             for recorder in self.recorders { recorder.record(value) }
         }
@@ -1662,6 +1766,10 @@ public final class MultiplexMetricsHandler: MetricsFactory {
         let timers: [TimerHandler]
         public init(factories: [MetricsFactory], label: String, dimensions: [(String, String)]) {
             self.timers = factories.map { $0.makeTimer(label: label, dimensions: dimensions) }
+        }
+
+        public init(factories: [MetricsFactory], descriptor: MetricDescriptor) {
+            self.timers = factories.map { $0.makeTimer(descriptor: descriptor) }
         }
 
         func recordNanoseconds(_ duration: Int64) {

--- a/Sources/MetricsTestKit/TestMetrics.swift
+++ b/Sources/MetricsTestKit/TestMetrics.swift
@@ -71,45 +71,65 @@ public final class TestMetrics: MetricsFactory {
     }
 
     public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+        self.makeCounter(descriptor: MetricDescriptor(label: label, dimensions: dimensions))
+    }
+
+    public func makeCounter(descriptor: MetricDescriptor) -> CounterHandler {
         self.lock.withLock { () -> CounterHandler in
-            if let existing = self._counters[.init(label: label, dimensions: dimensions)] {
+            let key = FullKey(label: descriptor.label, dimensions: descriptor.dimensions)
+            if let existing = self._counters[key] {
                 return existing
             }
-            let item = TestCounter(label: label, dimensions: dimensions)
-            self._counters[.init(label: label, dimensions: dimensions)] = item
+            let item = TestCounter(descriptor: descriptor)
+            self._counters[key] = item
             return item
         }
     }
 
     public func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
+        self.makeMeter(descriptor: MetricDescriptor(label: label, dimensions: dimensions))
+    }
+
+    public func makeMeter(descriptor: MetricDescriptor) -> MeterHandler {
         self.lock.withLock { () -> MeterHandler in
-            if let existing = self._meters[.init(label: label, dimensions: dimensions)] {
+            let key = FullKey(label: descriptor.label, dimensions: descriptor.dimensions)
+            if let existing = self._meters[key] {
                 return existing
             }
-            let item = TestMeter(label: label, dimensions: dimensions)
-            self._meters[.init(label: label, dimensions: dimensions)] = item
+            let item = TestMeter(descriptor: descriptor)
+            self._meters[key] = item
             return item
         }
     }
 
     public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
+        self.makeRecorder(descriptor: MetricDescriptor(label: label, dimensions: dimensions), aggregate: aggregate)
+    }
+
+    public func makeRecorder(descriptor: MetricDescriptor, aggregate: Bool) -> RecorderHandler {
         self.lock.withLock { () -> RecorderHandler in
-            if let existing = self._recorders[.init(label: label, dimensions: dimensions)] {
+            let key = FullKey(label: descriptor.label, dimensions: descriptor.dimensions)
+            if let existing = self._recorders[key] {
                 return existing
             }
-            let item = TestRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
-            self._recorders[.init(label: label, dimensions: dimensions)] = item
+            let item = TestRecorder(descriptor: descriptor, aggregate: aggregate)
+            self._recorders[key] = item
             return item
         }
     }
 
     public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
+        self.makeTimer(descriptor: MetricDescriptor(label: label, dimensions: dimensions))
+    }
+
+    public func makeTimer(descriptor: MetricDescriptor) -> TimerHandler {
         self.lock.withLock { () -> TimerHandler in
-            if let existing = self._timers[.init(label: label, dimensions: dimensions)] {
+            let key = FullKey(label: descriptor.label, dimensions: descriptor.dimensions)
+            if let existing = self._timers[key] {
                 return existing
             }
-            let item = TestTimer(label: label, dimensions: dimensions)
-            self._timers[.init(label: label, dimensions: dimensions)] = item
+            let item = TestTimer(descriptor: descriptor)
+            self._timers[key] = item
             return item
         }
     }
@@ -378,8 +398,10 @@ public protocol TestMetric {
 /// A test counter that you can inspect.
 public final class TestCounter: TestMetric, CounterHandler, Equatable {
     public let id: String
-    public let label: String
-    public let dimensions: [(String, String)]
+    /// The descriptor the counter was created from, including its optional description.
+    public let descriptor: MetricDescriptor
+    public var label: String { self.descriptor.label }
+    public var dimensions: [(String, String)] { self.descriptor.dimensions }
 
     public var key: TestMetrics.FullKey {
         TestMetrics.FullKey(label: self.label, dimensions: self.dimensions)
@@ -388,10 +410,9 @@ public final class TestCounter: TestMetric, CounterHandler, Equatable {
     let lock = NSLock()
     private var _values = [(Date, Int64)]()
 
-    init(label: String, dimensions: [(String, String)]) {
+    init(descriptor: MetricDescriptor) {
         self.id = UUID().uuidString
-        self.label = label
-        self.dimensions = dimensions
+        self.descriptor = descriptor
     }
 
     public func increment(by amount: Int64) {
@@ -434,8 +455,10 @@ public final class TestCounter: TestMetric, CounterHandler, Equatable {
 /// A test meter that you can inspect.
 public final class TestMeter: TestMetric, MeterHandler, Equatable {
     public let id: String
-    public let label: String
-    public let dimensions: [(String, String)]
+    /// The descriptor the meter was created from, including its optional description.
+    public let descriptor: MetricDescriptor
+    public var label: String { self.descriptor.label }
+    public var dimensions: [(String, String)] { self.descriptor.dimensions }
 
     public var key: TestMetrics.FullKey {
         TestMetrics.FullKey(label: self.label, dimensions: self.dimensions)
@@ -444,10 +467,9 @@ public final class TestMeter: TestMetric, MeterHandler, Equatable {
     let lock = NSLock()
     private var _values = [(Date, Double)]()
 
-    init(label: String, dimensions: [(String, String)]) {
+    init(descriptor: MetricDescriptor) {
         self.id = UUID().uuidString
-        self.label = label
-        self.dimensions = dimensions
+        self.descriptor = descriptor
     }
 
     public func set(_ value: Int64) {
@@ -537,8 +559,10 @@ public final class TestMeter: TestMetric, MeterHandler, Equatable {
 /// A test recorder that you can inspect.
 public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
     public let id: String
-    public let label: String
-    public let dimensions: [(String, String)]
+    /// The descriptor the recorder was created from, including its optional description.
+    public let descriptor: MetricDescriptor
+    public var label: String { self.descriptor.label }
+    public var dimensions: [(String, String)] { self.descriptor.dimensions }
     public let aggregate: Bool
 
     public var key: TestMetrics.FullKey {
@@ -548,10 +572,9 @@ public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
     let lock = NSLock()
     private var _values = [(Date, Double)]()
 
-    init(label: String, dimensions: [(String, String)], aggregate: Bool) {
+    init(descriptor: MetricDescriptor, aggregate: Bool) {
         self.id = UUID().uuidString
-        self.label = label
-        self.dimensions = dimensions
+        self.descriptor = descriptor
         self.aggregate = aggregate
     }
 
@@ -590,9 +613,11 @@ public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
 /// A test timer that you can inspect.
 public final class TestTimer: TestMetric, TimerHandler, Equatable {
     public let id: String
-    public let label: String
+    /// The descriptor the timer was created from, including its optional description.
+    public let descriptor: MetricDescriptor
+    public var label: String { self.descriptor.label }
     public var displayUnit: TimeUnit?
-    public let dimensions: [(String, String)]
+    public var dimensions: [(String, String)] { self.descriptor.dimensions }
 
     public var key: TestMetrics.FullKey {
         TestMetrics.FullKey(label: self.label, dimensions: self.dimensions)
@@ -601,11 +626,10 @@ public final class TestTimer: TestMetric, TimerHandler, Equatable {
     let lock = NSLock()
     private var _values = [(Date, Int64)]()
 
-    init(label: String, dimensions: [(String, String)]) {
+    init(descriptor: MetricDescriptor) {
         self.id = UUID().uuidString
-        self.label = label
+        self.descriptor = descriptor
         self.displayUnit = nil
-        self.dimensions = dimensions
     }
 
     public func preferDisplayUnit(_ unit: TimeUnit) {

--- a/Tests/MetricsTests/MetricDescriptorTests.swift
+++ b/Tests/MetricsTests/MetricDescriptorTests.swift
@@ -1,0 +1,332 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Metrics API open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Metrics API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+import MetricsTestKit
+import Testing
+
+struct MetricDescriptorTests {
+    // MARK: - MetricDescriptor
+
+    @Test func descriptorDefaultsToNoDimensionsAndNoDescription() {
+        let descriptor = MetricDescriptor(label: "my_metric")
+        #expect(descriptor.label == "my_metric")
+        #expect(descriptor.dimensions.isEmpty)
+        #expect(descriptor.description == nil)
+    }
+
+    @Test func descriptorEquality() {
+        let lhs = MetricDescriptor(label: "l", dimensions: [("a", "b")], description: "d")
+        #expect(lhs == MetricDescriptor(label: "l", dimensions: [("a", "b")], description: "d"))
+        #expect(lhs != MetricDescriptor(label: "other", dimensions: [("a", "b")], description: "d"))
+        #expect(lhs != MetricDescriptor(label: "l", dimensions: [("a", "c")], description: "d"))
+        #expect(lhs != MetricDescriptor(label: "l", dimensions: [("a", "b")], description: nil))
+    }
+
+    // MARK: - Descriptor-based metric creation
+
+    @Test func counterCarriesDescriptionToBackend() throws {
+        let metrics = TestMetrics()
+        let descriptor = MetricDescriptor(
+            label: "requests_total",
+            dimensions: [("method", "GET")],
+            description: "Total number of requests."
+        )
+
+        let counter = Counter(descriptor: descriptor, factory: metrics)
+        counter.increment(by: 5)
+
+        let testCounter = try metrics.expectCounter("requests_total", [("method", "GET")])
+        #expect(testCounter.descriptor == descriptor)
+        #expect(testCounter.descriptor.description == "Total number of requests.")
+        #expect(testCounter.totalValue == 5)
+        #expect(counter.label == "requests_total")
+    }
+
+    @Test func meterCarriesDescriptionToBackend() throws {
+        let metrics = TestMetrics()
+        let descriptor = MetricDescriptor(label: "temperature", description: "Current temperature in celsius.")
+
+        let meter = Meter(descriptor: descriptor, factory: metrics)
+        meter.set(21.5)
+
+        let testMeter = try metrics.expectMeter("temperature")
+        #expect(testMeter.descriptor.description == "Current temperature in celsius.")
+        #expect(testMeter.lastValue == 21.5)
+    }
+
+    @Test func recorderCarriesDescriptionToBackend() throws {
+        let metrics = TestMetrics()
+        let descriptor = MetricDescriptor(label: "response_size", description: "Response sizes in bytes.")
+
+        let recorder = Recorder(descriptor: descriptor, factory: metrics)
+        recorder.record(1024)
+
+        let testRecorder = try metrics.expectRecorder("response_size")
+        #expect(testRecorder.descriptor.description == "Response sizes in bytes.")
+        #expect(testRecorder.aggregate)
+        #expect(testRecorder.lastValue == 1024)
+    }
+
+    @Test func gaugeCarriesDescriptionToBackend() throws {
+        let metrics = TestMetrics()
+        let descriptor = MetricDescriptor(label: "active_threads", description: "Number of active threads.")
+
+        let gauge = Gauge(descriptor: descriptor, factory: metrics)
+        gauge.record(7)
+
+        let testRecorder = try metrics.expectGauge("active_threads")
+        #expect(testRecorder.descriptor.description == "Number of active threads.")
+        #expect(!testRecorder.aggregate)
+        #expect(testRecorder.lastValue == 7)
+    }
+
+    @Test func timerCarriesDescriptionToBackend() throws {
+        let metrics = TestMetrics()
+        let descriptor = MetricDescriptor(label: "request_duration", description: "Request durations.")
+
+        let timer = Timer(descriptor: descriptor, factory: metrics)
+        timer.recordNanoseconds(42)
+
+        let testTimer = try metrics.expectTimer("request_duration")
+        #expect(testTimer.descriptor.description == "Request durations.")
+        #expect(testTimer.lastValue == 42)
+    }
+
+    @Test func timerWithPreferredDisplayUnitCarriesDescriptionToBackend() throws {
+        let metrics = TestMetrics()
+        let descriptor = MetricDescriptor(label: "job_duration", description: "Job durations.")
+
+        let timer = Timer(descriptor: descriptor, preferredDisplayUnit: .seconds, factory: metrics)
+        timer.recordSeconds(2)
+
+        let testTimer = try metrics.expectTimer("job_duration")
+        #expect(testTimer.descriptor.description == "Job durations.")
+        #expect(testTimer.displayUnit == .seconds)
+        #expect(testTimer.valueInPreferredUnit(atIndex: 0) == 2.0)
+    }
+
+    @Test func floatingPointCounterFallsBackToWrappedCounter() throws {
+        // TestMetrics does not natively support floating-point counters, so the default
+        // accumulating implementation kicks in and wraps a regular counter. The description is
+        // dropped by the compatibility fallback, but values must still flow.
+        let metrics = TestMetrics()
+        let descriptor = MetricDescriptor(label: "fp_total", description: "dropped by fallback")
+
+        let counter = FloatingPointCounter(descriptor: descriptor, factory: metrics)
+        counter.increment(by: 2.5)
+        counter.increment(by: 2.5)
+
+        let testCounter = try metrics.expectCounter("fp_total")
+        #expect(testCounter.descriptor.description == nil)
+        #expect(testCounter.totalValue == 5)
+    }
+
+    // MARK: - Backwards compatibility
+
+    @Test func legacyFactoryReceivesLabelAndDimensionsViaDefaultImplementation() throws {
+        let legacy = LegacyOnlyFactory()
+        let descriptor = MetricDescriptor(
+            label: "legacy_metric",
+            dimensions: [("a", "b")],
+            description: "not visible to legacy backends"
+        )
+
+        let counter = Counter(descriptor: descriptor, factory: legacy)
+        counter.increment()
+
+        let handler = try #require(legacy.counter)
+        #expect(handler.label == "legacy_metric")
+        #expect(handler.dimensions.count == 1)
+        #expect(handler.values == [1])
+    }
+
+    @Test func legacyFactoryPathCreatesMetricWithoutDescription() throws {
+        let metrics = TestMetrics()
+
+        let counter = Counter(label: "no_description", dimensions: [], factory: metrics)
+        counter.increment()
+
+        let testCounter = try metrics.expectCounter("no_description")
+        #expect(testCounter.descriptor == MetricDescriptor(label: "no_description"))
+        #expect(testCounter.descriptor.description == nil)
+    }
+
+    @Test func descriptorAwareFactoryReceivesFullDescriptor() {
+        let factory = DescriptorRecordingFactory()
+        let descriptor = MetricDescriptor(label: "observed", description: "visible to aware backends")
+
+        _ = Counter(descriptor: descriptor, factory: factory)
+        _ = Timer(descriptor: descriptor, factory: factory)
+
+        #expect(factory.receivedDescriptors == [descriptor, descriptor])
+    }
+
+    @Test func factoryReturnsSameHandlerForSameLabelAndDimensions() {
+        let metrics = TestMetrics()
+        let first = metrics.makeCounter(descriptor: MetricDescriptor(label: "dup", description: "first"))
+        let second = metrics.makeCounter(descriptor: MetricDescriptor(label: "dup", description: "second"))
+        #expect(first === second)
+        #expect((first as? TestCounter)?.descriptor.description == "first")
+    }
+
+    // MARK: - Factory combinators
+
+    @Test func multiplexForwardsDescriptorToAllFactories() throws {
+        let first = TestMetrics()
+        let second = TestMetrics()
+        let multiplex = MultiplexMetricsHandler(factories: [first, second])
+        let descriptor = MetricDescriptor(label: "muxed", description: "seen by all backends")
+
+        let counter = Counter(descriptor: descriptor, factory: multiplex)
+        counter.increment(by: 3)
+
+        for metrics in [first, second] {
+            let testCounter = try metrics.expectCounter("muxed")
+            #expect(testCounter.descriptor.description == "seen by all backends")
+            #expect(testCounter.totalValue == 3)
+        }
+    }
+
+    @Test func mappingFactoryTransformsIdentityAndPreservesDescription() throws {
+        let upstream = TestMetrics()
+        let factory = upstream.withLabelAndDimensionsMapping { label, dimensions in
+            ("prefix_\(label)", dimensions + [("service", "test")])
+        }
+        let descriptor = MetricDescriptor(label: "mapped", description: "survives mapping")
+
+        let counter = Counter(descriptor: descriptor, factory: factory)
+        counter.increment()
+
+        let testCounter = try upstream.expectCounter("prefix_mapped", [("service", "test")])
+        #expect(testCounter.descriptor.description == "survives mapping")
+    }
+}
+
+// MARK: - Test fixtures
+
+/// A factory that only implements the pre-descriptor `MetricsFactory` requirements, proving that
+/// existing backend implementations keep compiling and working when metrics are created through
+/// the descriptor-based APIs.
+private final class LegacyOnlyFactory: MetricsFactory, @unchecked Sendable {
+    private let lock = Lock()
+    private var _counter: RecordingCounter?
+
+    var counter: RecordingCounter? {
+        self.lock.withLock { self._counter }
+    }
+
+    func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+        let counter = RecordingCounter(label: label, dimensions: dimensions)
+        self.lock.withLockVoid { self._counter = counter }
+        return counter
+    }
+
+    func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
+        NOOPMetricsHandler.instance.makeMeter(label: label, dimensions: dimensions)
+    }
+
+    func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
+        NOOPMetricsHandler.instance.makeRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
+    }
+
+    func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
+        NOOPMetricsHandler.instance.makeTimer(label: label, dimensions: dimensions)
+    }
+
+    func destroyCounter(_ handler: CounterHandler) {}
+    func destroyMeter(_ handler: MeterHandler) {}
+    func destroyRecorder(_ handler: RecorderHandler) {}
+    func destroyTimer(_ handler: TimerHandler) {}
+
+    final class RecordingCounter: CounterHandler, @unchecked Sendable {
+        let label: String
+        let dimensions: [(String, String)]
+        private let lock = Lock()
+        private var _values: [Int64] = []
+
+        var values: [Int64] {
+            self.lock.withLock { self._values }
+        }
+
+        init(label: String, dimensions: [(String, String)]) {
+            self.label = label
+            self.dimensions = dimensions
+        }
+
+        func increment(by amount: Int64) {
+            self.lock.withLockVoid { self._values.append(amount) }
+        }
+
+        func reset() {
+            self.lock.withLockVoid { self._values = [] }
+        }
+    }
+}
+
+/// A factory that implements the descriptor-based requirements and records every descriptor it
+/// receives, proving that descriptor-aware backends are dispatched to through the protocol.
+private final class DescriptorRecordingFactory: MetricsFactory, @unchecked Sendable {
+    private let lock = Lock()
+    private var _receivedDescriptors: [MetricDescriptor] = []
+
+    var receivedDescriptors: [MetricDescriptor] {
+        self.lock.withLock { self._receivedDescriptors }
+    }
+
+    private func record(_ descriptor: MetricDescriptor) {
+        self.lock.withLockVoid { self._receivedDescriptors.append(descriptor) }
+    }
+
+    func makeCounter(descriptor: MetricDescriptor) -> CounterHandler {
+        self.record(descriptor)
+        return self.makeCounter(label: descriptor.label, dimensions: descriptor.dimensions)
+    }
+
+    func makeMeter(descriptor: MetricDescriptor) -> MeterHandler {
+        self.record(descriptor)
+        return self.makeMeter(label: descriptor.label, dimensions: descriptor.dimensions)
+    }
+
+    func makeRecorder(descriptor: MetricDescriptor, aggregate: Bool) -> RecorderHandler {
+        self.record(descriptor)
+        return self.makeRecorder(label: descriptor.label, dimensions: descriptor.dimensions, aggregate: aggregate)
+    }
+
+    func makeTimer(descriptor: MetricDescriptor) -> TimerHandler {
+        self.record(descriptor)
+        return self.makeTimer(label: descriptor.label, dimensions: descriptor.dimensions)
+    }
+
+    func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+        NOOPMetricsHandler.instance.makeCounter(label: label, dimensions: dimensions)
+    }
+
+    func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
+        NOOPMetricsHandler.instance.makeMeter(label: label, dimensions: dimensions)
+    }
+
+    func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
+        NOOPMetricsHandler.instance.makeRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
+    }
+
+    func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
+        NOOPMetricsHandler.instance.makeTimer(label: label, dimensions: dimensions)
+    }
+
+    func destroyCounter(_ handler: CounterHandler) {}
+    func destroyMeter(_ handler: MeterHandler) {}
+    func destroyRecorder(_ handler: RecorderHandler) {}
+    func destroyTimer(_ handler: TimerHandler) {}
+}


### PR DESCRIPTION
### Motivation

Relates to #236. Swift Metrics currently passes only a label and dimensions to backends, so there is no portable way to express a Prometheus/OpenMetrics `HELP` line or an OTLP instrument `description`. Today `swift-prometheus` exposes a separate registry API taking `help:`, and `swift-otel` works around it via dimensions.

### Status: proof of concept, not a merge request

Per the review feedback on #237 — "I strongly recommend to provide a PoC with the proposed solution" — this is the PoC implementation to accompany an SMT proposal, rather than something to land ahead of that process. Opening it as a PR so the diff is reviewable and CI runs against it; happy to convert it to a draft, or close it and keep it as a branch link under the proposal's *Implementation* heading, whichever fits the Proposals workflow better.

### Design

- **`MetricDescriptor`** (`Sendable`, `Equatable`) in `CoreMetrics`: `label`, `dimensions`, and an optional `description`, with an evolvable memberwise init — the "hypothetical struct" from the issue, so future fields (unit, etc.) don't require new factory methods.
- **Five new `MetricsFactory` requirements** — `makeCounter(descriptor:)`, `makeFloatingPointCounter(descriptor:)`, `makeMeter(descriptor:)`, `makeRecorder(descriptor:aggregate:)`, `makeTimer(descriptor:)` — **each with a default implementation** that forwards label and dimensions to the existing `makeXXX(label:dimensions:)` methods. Existing backends compile and behave unchanged; descriptor-aware backends override to receive the description.
- **Descriptor-based convenience initializers** on `Counter`, `FloatingPointCounter`, `Meter`, `Gauge`, `Recorder`, and `Timer` (including the `preferredDisplayUnit` variant). No existing signature was changed or removed.
- **`MultiplexMetricsHandler`** forwards descriptors to every sub-factory; **`MappingMetricsFactory`** transforms label/dimensions while preserving the description; **`TestMetrics`** stores the full descriptor (with `label`/`dimensions` becoming computed properties, so existing reads still work) so tests can assert on descriptions.

### Validation

- `swift test` — 132 tests pass (22 new), including coverage for legacy-only factories, descriptor-aware dispatch, multiplex and mapping propagation, dimension dedupe, and the floating-point-counter fallback.
- `swift package diagnose-api-breaking-changes` — **no breaking changes** in `CoreMetrics`, `Metrics`, or `MetricsTestKit`.
- Builds clean under `-warnings-as-errors -require-explicit-sendable`.
- `swift format lint` clean apart from two findings that are pre-existing on `main`.
- `Sources/CoreMetrics/CMakeLists.txt` updated for the `cmake-lists` check added in #238.

### Open questions for review

- Naming: `MetricDescriptor` here, versus `MetricDescription` as floated in the issue.
- Whether `aggregate` belongs inside the descriptor for `Recorder`, rather than staying a separate parameter.
- Whether the default-implementation fallback should be silent, as here, or surface that a description was dropped.
